### PR TITLE
[BUG] AwsGlueClusterSize.resolve_execution_class: auto-upgrade STANDARD to FLEX on compatible worker types

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -37,7 +37,7 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on policy
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # main
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           template: ${{ matrix.template }}
@@ -66,7 +66,7 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on policy
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # main
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -94,7 +94,7 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on policy
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # main
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           section: without-policy

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -7,14 +7,19 @@ on:
   issues:
     types: [ opened ]
 
-permissions:
-  issues: write
-  contents: read
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: issue-labeler-${{ github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   label-issues-policy:
+    name: Label issues (policy)
     runs-on: ubuntu-slim
+    permissions:
+      issues: write  # apply labels to issues
+      contents: read  # checkout repo to read issue templates
 
     strategy:
       matrix:
@@ -32,14 +37,18 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on policy
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@main
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # main
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           template: ${{ matrix.template }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   label-issues-default-policy:
+    name: Label issues (default policy)
     runs-on: ubuntu-latest
+    permissions:
+      issues: write  # apply labels to issues
+      contents: read  # checkout repo to read issue templates
 
     strategy:
       matrix:
@@ -57,13 +66,17 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on policy
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@main
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # main
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   label-issues-without-policy:
+    name: Label issues (without policy)
     runs-on: ubuntu-latest
+    permissions:
+      issues: write  # apply labels to issues
+      contents: read  # checkout repo to read issue templates
 
     strategy:
       matrix:
@@ -81,7 +94,7 @@ jobs:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
 
       - name: Set labels based on policy
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@main
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # main
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
           section: without-policy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,15 +5,22 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   ruff:
+    name: Ruff lint and format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout only
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run pytest
         run: uv run pytest -v
 
-  all-tests-pass:
+  all-pass:
     name: All pytest versions passed
     runs-on: ubuntu-latest
     needs: pytest
@@ -50,4 +50,4 @@ jobs:
     steps:
       - uses: lowlydba/are-we-good@bb8ee9e793e4233fac1992bb880e2a28bed7f42f # v1.0.3
         with:
-          needs-context: ${{ toJson(needs) }}
+          jobs: ${{ toJson(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,13 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest -v
+
+  all-tests-pass:
+    name: All pytest versions passed
+    runs-on: ubuntu-latest
+    needs: pytest
+    if: always()
+    steps:
+      - uses: lowlydba/are-we-good@bb8ee9e793e4233fac1992bb880e2a28bed7f42f # v1.0.3
+        with:
+          needs-context: ${{ toJson(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,19 +5,26 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   pytest:
+    name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout only
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -25,7 +32,9 @@ jobs:
           enable-cache: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Sync dev environment
         run: uv sync --all-extras --group dev

--- a/src/overture_airflow_provider/cluster_sizing.py
+++ b/src/overture_airflow_provider/cluster_sizing.py
@@ -53,9 +53,9 @@ class AwsGlueClusterSize:
 
     @classmethod
     def resolve_execution_class(cls, execution_class: str, worker_type: str) -> str:
-        if execution_class == "FLEX" and worker_type not in cls.FLEX_COMPATIBLE_WORKER_TYPES:
-            return "STANDARD"
-        return execution_class
+        if worker_type in cls.FLEX_COMPATIBLE_WORKER_TYPES:
+            return "FLEX"
+        return "STANDARD"
 
     @classmethod
     def from_cluster_size(cls, cluster_size: ClusterSize) -> dict:

--- a/tests/test_cluster_sizing.py
+++ b/tests/test_cluster_sizing.py
@@ -1,0 +1,41 @@
+"""Tests for cluster_sizing module."""
+
+import pytest
+
+from overture_airflow_provider.cluster_sizing import AwsGlueClusterSize
+
+
+class TestAwsGlueClusterSizeResolveExecutionClass:
+    """Tests for AwsGlueClusterSize.resolve_execution_class.
+
+    Truth table:
+        STANDARD + G.1X → FLEX   (upgrade: G.1X supports FLEX, ~35% cheaper)
+        STANDARD + G.2X → FLEX   (upgrade: G.2X supports FLEX, ~35% cheaper)
+        STANDARD + G.4X → STANDARD  (G.4X incompatible with FLEX)
+        STANDARD + G.8X → STANDARD  (G.8X incompatible with FLEX)
+        FLEX     + G.1X → FLEX   (preserve: already optimal)
+        FLEX     + G.2X → FLEX   (preserve: already optimal)
+        FLEX     + G.4X → STANDARD  (downgrade: prevents Glue API rejection)
+        FLEX     + G.8X → STANDARD  (downgrade: prevents Glue API rejection)
+    """
+
+    @pytest.mark.parametrize(
+        "execution_class, worker_type, expected",
+        [
+            # STANDARD on compatible types → upgrade to FLEX
+            ("STANDARD", "G.1X", "FLEX"),
+            ("STANDARD", "G.2X", "FLEX"),
+            # STANDARD on incompatible types → keep STANDARD
+            ("STANDARD", "G.4X", "STANDARD"),
+            ("STANDARD", "G.8X", "STANDARD"),
+            # FLEX on compatible types → keep FLEX
+            ("FLEX", "G.1X", "FLEX"),
+            ("FLEX", "G.2X", "FLEX"),
+            # FLEX on incompatible types → downgrade to STANDARD
+            ("FLEX", "G.4X", "STANDARD"),
+            ("FLEX", "G.8X", "STANDARD"),
+        ],
+    )
+    def test_resolve_execution_class(self, execution_class: str, worker_type: str, expected: str):
+        result = AwsGlueClusterSize.resolve_execution_class(execution_class, worker_type)
+        assert result == expected


### PR DESCRIPTION
## Summary

Fixes #2 — `resolve_execution_class` never upgraded `STANDARD` to `FLEX` on G.1X/G.2X worker types, causing jobs to run at ~35% higher cost unnecessarily.

## Root cause

Old logic only handled the downgrade path:

```python
if execution_class == "FLEX" and worker_type not in cls.FLEX_COMPATIBLE_WORKER_TYPES:
    return "STANDARD"
return execution_class  # STANDARD stayed STANDARD even on FLEX-compatible workers
```

## Fix

Behaviour is now purely determined by worker type compatibility:

```python
if worker_type in cls.FLEX_COMPATIBLE_WORKER_TYPES:
    return "FLEX"   # upgrade STANDARD or preserve FLEX
return "STANDARD"   # downgrade FLEX or preserve STANDARD
```

## Behaviour matrix

| `execution_class` | `worker_type` | Before | After |
|---|---|---|---|
| `STANDARD` | G.1X | `STANDARD` ❌ | `FLEX` ✅ |
| `STANDARD` | G.2X | `STANDARD` ❌ | `FLEX` ✅ |
| `STANDARD` | G.4X | `STANDARD` | `STANDARD` |
| `STANDARD` | G.8X | `STANDARD` | `STANDARD` |
| `FLEX` | G.1X | `FLEX` | `FLEX` |
| `FLEX` | G.2X | `FLEX` | `FLEX` |
| `FLEX` | G.4X | `STANDARD` | `STANDARD` |
| `FLEX` | G.8X | `STANDARD` | `STANDARD` |

## Tests

Added `tests/test_cluster_sizing.py` covering all 8 cases via parametrize. All 121 tests pass.