### PR TITLE
[FEATURE] Add S3 Tables Iceberg catalog support to IcebergConfig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,16 @@ Fields are `domain`, `domain_owner`, `repository`, `region`,
 
 ### IcebergConfig
 
-Holds two JSON-string fields: `spark_config` (Glue/Databricks) and
-`wherobots_spark_config` (Wherobots GlueCatalog). Not a warehouse/URI struct.
+Holds four JSON-string fields:
+
+- `spark_config` (Glue/Databricks primary catalog, typically REST)
+- `wherobots_spark_config` (Wherobots primary catalog, typically GlueCatalog)
+- `s3tables_spark_config` (Glue/Databricks S3 Tables catalog — coexists with primary)
+- `wherobots_s3tables_spark_config` (Wherobots S3 Tables catalog variant)
+
+S3 Tables keys must be namespaced under a distinct catalog alias (e.g.
+`spark.sql.catalog.s3tables_catalog.*`) to avoid conflicts with the primary
+catalog. Both primary and S3 Tables configs are merged together at runtime.
 
 ### DatabricksConfig
 

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -124,19 +124,37 @@ class IcebergConfig:
     - ``wherobots_spark_config`` — for Wherobots. Typically a ``GlueCatalog``
       configuration accessed via cross-account credential delegation.
 
-    The task group selects the right variant at runtime based on the resolved
-    platform family. Pass only the variants you need; omit ``iceberg_config``
-    entirely for jobs that do not use Iceberg.
+    Additionally, S3 Tables catalog configuration can coexist alongside the
+    primary catalog:
+
+    - ``s3tables_spark_config`` — for Glue and Databricks. Configures an
+      additional ``s3tables_catalog`` using the S3 Tables REST API with SigV4
+      signing.
+    - ``wherobots_s3tables_spark_config`` — for Wherobots. S3 Tables catalog
+      variant using Wherobots credential delegation.
+
+    The task group selects the right variants at runtime based on the resolved
+    platform family and merges them together. Pass only the variants you need;
+    omit ``iceberg_config`` entirely for jobs that do not use Iceberg.
 
     Args:
         spark_config: Iceberg Spark config JSON string for Glue/Databricks.
             Defaults to ``"{}"`` (no Iceberg).
         wherobots_spark_config: Iceberg Spark config JSON string for Wherobots.
             Defaults to ``"{}"`` (no Iceberg).
+        s3tables_spark_config: S3 Tables catalog config JSON string for
+            Glue/Databricks. Merged alongside the primary catalog config.
+            Keys should be namespaced under a distinct catalog alias (e.g.
+            ``spark.sql.catalog.s3tables_catalog.*``). Defaults to ``"{}"``
+            (no S3 Tables catalog).
+        wherobots_s3tables_spark_config: S3 Tables catalog config JSON string
+            for Wherobots. Defaults to ``"{}"`` (no S3 Tables catalog).
     """
 
     spark_config: str = "{}"
     wherobots_spark_config: str = "{}"
+    s3tables_spark_config: str = "{}"
+    wherobots_s3tables_spark_config: str = "{}"
 
 
 @dataclass

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -152,9 +152,7 @@ def _select_iceberg_spark_config(
         return {}
 
     if family == SparkFamily.WHEROBOTS:
-        primary = _load_json_config(
-            iceberg_config.wherobots_spark_config, "wherobots_spark_config"
-        )
+        primary = _load_json_config(iceberg_config.wherobots_spark_config, "wherobots_spark_config")
         s3tables = _load_json_config(
             iceberg_config.wherobots_s3tables_spark_config,
             "wherobots_s3tables_spark_config",

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -126,6 +126,49 @@ def _jsonify(obj: Any) -> Any:
     return obj
 
 
+def _load_json_config(raw: str | None, field_name: str) -> dict[str, Any]:
+    """Parse a JSON config string and require a JSON object payload."""
+    if not raw or raw == "{}":
+        return {}
+
+    try:
+        loaded = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        detail = exc.msg if isinstance(exc, json.JSONDecodeError) else str(exc)
+        raise ValueError(f"Invalid JSON in IcebergConfig.{field_name}: {detail}") from exc
+
+    if not isinstance(loaded, dict):
+        raise ValueError(
+            f"IcebergConfig.{field_name} must decode to a JSON object, got {type(loaded).__name__}"
+        )
+    return loaded
+
+
+def _select_iceberg_spark_config(
+    iceberg_config: IcebergConfig | None, family: SparkFamily
+) -> dict[str, Any]:
+    """Resolve and merge the Iceberg config variants for the selected Spark family."""
+    if iceberg_config is None:
+        return {}
+
+    if family == SparkFamily.WHEROBOTS:
+        primary = _load_json_config(
+            iceberg_config.wherobots_spark_config, "wherobots_spark_config"
+        )
+        s3tables = _load_json_config(
+            iceberg_config.wherobots_s3tables_spark_config,
+            "wherobots_s3tables_spark_config",
+        )
+    else:
+        primary = _load_json_config(iceberg_config.spark_config, "spark_config")
+        s3tables = _load_json_config(
+            iceberg_config.s3tables_spark_config,
+            "s3tables_spark_config",
+        )
+
+    return {**primary, **s3tables}
+
+
 def _build_render_setup_info(
     spark_impl_name: str,
     sedona_version: str,
@@ -406,28 +449,7 @@ def render_spark_job(
     family: SparkFamily = setup_info["spark_family"]
 
     # Resolve which Iceberg config variant applies for this family.
-    iceberg_spark_config = None
-    if family == SparkFamily.WHEROBOTS:
-        try:
-            primary = json.loads(iceberg_config.wherobots_spark_config) or {}
-        except (TypeError, ValueError):
-            primary = {}
-        try:
-            s3tables = json.loads(iceberg_config.wherobots_s3tables_spark_config) or {}
-        except (TypeError, ValueError):
-            s3tables = {}
-    else:
-        try:
-            primary = json.loads(iceberg_config.spark_config) or {}
-        except (TypeError, ValueError):
-            primary = {}
-        try:
-            s3tables = json.loads(iceberg_config.s3tables_spark_config) or {}
-        except (TypeError, ValueError):
-            s3tables = {}
-
-    if primary or s3tables:
-        iceberg_spark_config = {**primary, **s3tables}
+    iceberg_spark_config = _select_iceberg_spark_config(iceberg_config, family) or None
 
     if family == SparkFamily.GLUE:
         package_info = _stub_package_info_glue(setup_info, pre_resolved_package_info)

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -409,14 +409,25 @@ def render_spark_job(
     iceberg_spark_config = None
     if family == SparkFamily.WHEROBOTS:
         try:
-            iceberg_spark_config = json.loads(iceberg_config.wherobots_spark_config) or None
+            primary = json.loads(iceberg_config.wherobots_spark_config) or {}
         except (TypeError, ValueError):
-            iceberg_spark_config = None
+            primary = {}
+        try:
+            s3tables = json.loads(iceberg_config.wherobots_s3tables_spark_config) or {}
+        except (TypeError, ValueError):
+            s3tables = {}
     else:
         try:
-            iceberg_spark_config = json.loads(iceberg_config.spark_config) or None
+            primary = json.loads(iceberg_config.spark_config) or {}
         except (TypeError, ValueError):
-            iceberg_spark_config = None
+            primary = {}
+        try:
+            s3tables = json.loads(iceberg_config.s3tables_spark_config) or {}
+        except (TypeError, ValueError):
+            s3tables = {}
+
+    if primary or s3tables:
+        iceberg_spark_config = {**primary, **s3tables}
 
     if family == SparkFamily.GLUE:
         package_info = _stub_package_info_glue(setup_info, pre_resolved_package_info)

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -210,16 +210,33 @@ def _parse_json_or_dict(value: Any) -> dict:
     return {}
 
 
+def _load_json_config(raw: str | None) -> dict:
+    """Parse a JSON config string, returning an empty dict for falsy/empty values."""
+    return json.loads(raw) if raw and raw != "{}" else {}
+
+
 def _select_iceberg_conf(iceberg_config: IcebergConfig | None, spark_family_name: str) -> dict:
-    """Pick the right Iceberg config variant for the resolved platform family."""
+    """Pick the right Iceberg config variants for the resolved platform family.
+
+    Merges the primary catalog config with the S3 Tables catalog config (when
+    present) into a single dict. S3 Tables keys are namespaced under a separate
+    catalog alias so they coexist without conflicts.
+    """
     if iceberg_config is None:
         return {}
-    raw = (
-        iceberg_config.wherobots_spark_config
-        if spark_family_name == "WHEROBOTS"
-        else iceberg_config.spark_config
-    )
-    return json.loads(raw) if raw and raw != "{}" else {}
+
+    if spark_family_name == "WHEROBOTS":
+        primary = _load_json_config(iceberg_config.wherobots_spark_config)
+        s3tables = _load_json_config(iceberg_config.wherobots_s3tables_spark_config)
+    else:
+        primary = _load_json_config(iceberg_config.spark_config)
+        s3tables = _load_json_config(iceberg_config.s3tables_spark_config)
+
+    if s3tables:
+        merged = dict(primary)
+        merged.update(s3tables)
+        return merged
+    return primary
 
 
 def _xcom_datetime_default(obj):

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -210,9 +210,21 @@ def _parse_json_or_dict(value: Any) -> dict:
     return {}
 
 
-def _load_json_config(raw: str | None) -> dict:
+def _load_json_config(raw: str | None, field_name: str = "config") -> dict:
     """Parse a JSON config string, returning an empty dict for falsy/empty values."""
-    return json.loads(raw) if raw and raw != "{}" else {}
+    if not raw or raw == "{}":
+        return {}
+
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in IcebergConfig.{field_name}: {exc.msg}") from exc
+
+    if not isinstance(loaded, dict):
+        raise ValueError(
+            f"IcebergConfig.{field_name} must decode to a JSON object, got {type(loaded).__name__}"
+        )
+    return loaded
 
 
 def _select_iceberg_conf(iceberg_config: IcebergConfig | None, spark_family_name: str) -> dict:
@@ -226,11 +238,18 @@ def _select_iceberg_conf(iceberg_config: IcebergConfig | None, spark_family_name
         return {}
 
     if spark_family_name == "WHEROBOTS":
-        primary = _load_json_config(iceberg_config.wherobots_spark_config)
-        s3tables = _load_json_config(iceberg_config.wherobots_s3tables_spark_config)
+        primary = _load_json_config(
+            iceberg_config.wherobots_spark_config, field_name="wherobots_spark_config"
+        )
+        s3tables = _load_json_config(
+            iceberg_config.wherobots_s3tables_spark_config,
+            field_name="wherobots_s3tables_spark_config",
+        )
     else:
-        primary = _load_json_config(iceberg_config.spark_config)
-        s3tables = _load_json_config(iceberg_config.s3tables_spark_config)
+        primary = _load_json_config(iceberg_config.spark_config, field_name="spark_config")
+        s3tables = _load_json_config(
+            iceberg_config.s3tables_spark_config, field_name="s3tables_spark_config"
+        )
 
     if s3tables:
         merged = dict(primary)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ that have the extras installed keep the real implementations.
 
 import importlib
 import sys
+import types
 from unittest.mock import MagicMock
 
 _OPTIONAL_MODULES = (
@@ -26,10 +27,25 @@ _OPTIONAL_MODULES = (
     "wherobots.db",
 )
 
+
+def _stub_module(name: str):
+    module = types.ModuleType(name)
+    module.__getattr__ = lambda attr: MagicMock(name=f"{name}.{attr}")
+    sys.modules[name] = module
+
+    if "." not in name:
+        return module
+
+    parent_name, child_name = name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name) or _stub_module(parent_name)
+    setattr(parent, child_name, module)
+    return module
+
+
 for _mod in _OPTIONAL_MODULES:
     if _mod in sys.modules:
         continue
     try:
         importlib.import_module(_mod)
     except Exception:
-        sys.modules[_mod] = MagicMock()
+        _stub_module(_mod)

--- a/tests/test_databricks_gpu.py
+++ b/tests/test_databricks_gpu.py
@@ -1,6 +1,7 @@
 """Tests for Databricks GPU discovery and override-merge guards."""
 
 import types
+from contextlib import contextmanager
 
 import pytest
 
@@ -39,10 +40,13 @@ class _FakeClusters:
 
 
 def _patch_workspace(monkeypatch, clusters):
-    import databricks.sdk as sdk
+    @contextmanager
+    def _fake_workspace_client(self):
+        yield types.SimpleNamespace(clusters=clusters)
 
     monkeypatch.setattr(
-        sdk, "WorkspaceClient", lambda *a, **k: types.SimpleNamespace(clusters=clusters)
+        "overture_airflow_provider.hooks.DatabricksSdkHook.get_workspace_client",
+        _fake_workspace_client,
     )
 
     class _Conn:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+from overture_airflow_provider.config import IcebergConfig
 from overture_airflow_provider.render import (
     RenderResult,
     _jsonify,
@@ -18,6 +19,42 @@ _COMMON_KWARGS = dict(
     parameters={"date": "2024-01-01"},
     job_name="snapshot",
 )
+
+
+def _rest_catalog_config():
+    return {
+        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        "spark.sql.defaultCatalog": "iceberg_catalog",
+        "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.iceberg_catalog.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
+        "spark.sql.catalog.iceberg_catalog.uri": "https://glue.us-west-2.amazonaws.com/iceberg",
+    }
+
+
+def _s3tables_catalog_config():
+    return {
+        "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.s3tables_catalog.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
+        "spark.sql.catalog.s3tables_catalog.uri": "https://s3tables.us-west-2.amazonaws.com/iceberg",
+        "spark.sql.catalog.s3tables_catalog.warehouse": "arn:aws:s3tables:us-west-2:123456789012:bucket/my-bucket",
+        "spark.sql.catalog.s3tables_catalog.rest.signing-name": "s3tables",
+    }
+
+
+def _wherobots_catalog_config():
+    return {
+        "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.iceberg_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+        "spark.sql.catalog.iceberg_catalog.warehouse": "s3://my-bucket/warehouse",
+    }
+
+
+def _wherobots_s3tables_catalog_config():
+    return {
+        "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.s3tables_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+        "spark.sql.catalog.s3tables_catalog.warehouse": "s3://my-bucket/s3tables-warehouse",
+    }
 
 
 @pytest.mark.parametrize(
@@ -70,6 +107,88 @@ def test_render_wherobots_skips_region_resolution():
     # Wherobots payload has no AWS Region enum — region stays a plain string.
     region = result.operator_kwargs.get("region") or result.submit_payload.get("region")
     assert isinstance(region, str)
+
+
+@pytest.mark.parametrize(
+    "spark_impl_name, iceberg_config, expected_primary, expected_s3tables",
+    [
+        (
+            "GLUE_v5",
+            IcebergConfig(
+                spark_config=json.dumps(_rest_catalog_config()),
+                s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+            ),
+            _rest_catalog_config(),
+            _s3tables_catalog_config(),
+        ),
+        (
+            "DATABRICKS_v15",
+            IcebergConfig(
+                spark_config=json.dumps(_rest_catalog_config()),
+                s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+            ),
+            _rest_catalog_config(),
+            _s3tables_catalog_config(),
+        ),
+        (
+            "WHEROBOTS_v1_5_0",
+            IcebergConfig(
+                wherobots_spark_config=json.dumps(_wherobots_catalog_config()),
+                wherobots_s3tables_spark_config=json.dumps(_wherobots_s3tables_catalog_config()),
+            ),
+            _wherobots_catalog_config(),
+            _wherobots_s3tables_catalog_config(),
+        ),
+    ],
+)
+def test_render_merges_primary_and_s3tables_iceberg_configs(
+    spark_impl_name, iceberg_config, expected_primary, expected_s3tables
+):
+    result = render_spark_job(
+        spark_impl_name=spark_impl_name,
+        iceberg_config=iceberg_config,
+        **_COMMON_KWARGS,
+    )
+
+    assert result.merged_spark_conf.items() >= expected_primary.items()
+    assert result.merged_spark_conf.items() >= expected_s3tables.items()
+
+
+@pytest.mark.parametrize(
+    "spark_impl_name, iceberg_config, expected_s3tables",
+    [
+        (
+            "GLUE_v5",
+            IcebergConfig(s3tables_spark_config=json.dumps(_s3tables_catalog_config())),
+            _s3tables_catalog_config(),
+        ),
+        (
+            "DATABRICKS_v15",
+            IcebergConfig(s3tables_spark_config=json.dumps(_s3tables_catalog_config())),
+            _s3tables_catalog_config(),
+        ),
+        (
+            "WHEROBOTS_v1_5_0",
+            IcebergConfig(
+                wherobots_s3tables_spark_config=json.dumps(
+                    _wherobots_s3tables_catalog_config()
+                )
+            ),
+            _wherobots_s3tables_catalog_config(),
+        ),
+    ],
+)
+def test_render_preserves_s3tables_only_iceberg_configs(
+    spark_impl_name, iceberg_config, expected_s3tables
+):
+    result = render_spark_job(
+        spark_impl_name=spark_impl_name,
+        iceberg_config=iceberg_config,
+        **_COMMON_KWARGS,
+    )
+
+    assert result.merged_spark_conf.items() >= expected_s3tables.items()
+    assert "spark.sql.catalog.iceberg_catalog" not in result.merged_spark_conf
 
 
 def test_render_write_to_creates_files(tmp_path):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -171,9 +171,7 @@ def test_render_merges_primary_and_s3tables_iceberg_configs(
         (
             "WHEROBOTS_v1_5_0",
             IcebergConfig(
-                wherobots_s3tables_spark_config=json.dumps(
-                    _wherobots_s3tables_catalog_config()
-                )
+                wherobots_s3tables_spark_config=json.dumps(_wherobots_s3tables_catalog_config())
             ),
             _wherobots_s3tables_catalog_config(),
         ),
@@ -212,9 +210,7 @@ def test_render_preserves_s3tables_only_iceberg_configs(
         ),
     ],
 )
-def test_render_rejects_invalid_iceberg_json(
-    spark_impl_name, iceberg_config, expected_error
-):
+def test_render_rejects_invalid_iceberg_json(spark_impl_name, iceberg_config, expected_error):
     with pytest.raises(ValueError, match=re.escape(expected_error)):
         render_spark_job(
             spark_impl_name=spark_impl_name,

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 
 import pytest
 
@@ -189,6 +190,37 @@ def test_render_preserves_s3tables_only_iceberg_configs(
 
     assert result.merged_spark_conf.items() >= expected_s3tables.items()
     assert "spark.sql.catalog.iceberg_catalog" not in result.merged_spark_conf
+
+
+@pytest.mark.parametrize(
+    "spark_impl_name, iceberg_config, expected_error",
+    [
+        (
+            "GLUE_v5",
+            IcebergConfig(spark_config="[]"),
+            "IcebergConfig.spark_config must decode to a JSON object, got list",
+        ),
+        (
+            "DATABRICKS_v15",
+            IcebergConfig(s3tables_spark_config='{"bad"'),
+            "Invalid JSON in IcebergConfig.s3tables_spark_config",
+        ),
+        (
+            "WHEROBOTS_v1_5_0",
+            IcebergConfig(wherobots_s3tables_spark_config='"bad"'),
+            "IcebergConfig.wherobots_s3tables_spark_config must decode to a JSON object, got str",
+        ),
+    ],
+)
+def test_render_rejects_invalid_iceberg_json(
+    spark_impl_name, iceberg_config, expected_error
+):
+    with pytest.raises(ValueError, match=re.escape(expected_error)):
+        render_spark_job(
+            spark_impl_name=spark_impl_name,
+            iceberg_config=iceberg_config,
+            **_COMMON_KWARGS,
+        )
 
 
 def test_render_write_to_creates_files(tmp_path):

--- a/tests/test_select_iceberg_conf.py
+++ b/tests/test_select_iceberg_conf.py
@@ -1,0 +1,122 @@
+"""Tests for _select_iceberg_conf with S3 Tables catalog coexistence."""
+
+import json
+
+from overture_airflow_provider.config import IcebergConfig
+from overture_airflow_provider.spark_agnostic_taskgroup import _select_iceberg_conf
+
+
+def _rest_catalog_config():
+    return {
+        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        "spark.sql.defaultCatalog": "iceberg_catalog",
+        "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.iceberg_catalog.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
+        "spark.sql.catalog.iceberg_catalog.uri": "https://glue.us-west-2.amazonaws.com/iceberg",
+    }
+
+
+def _s3tables_catalog_config():
+    return {
+        "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.s3tables_catalog.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
+        "spark.sql.catalog.s3tables_catalog.uri": "https://s3tables.us-west-2.amazonaws.com/iceberg",
+        "spark.sql.catalog.s3tables_catalog.warehouse": "arn:aws:s3tables:us-west-2:123456789012:bucket/my-bucket",
+        "spark.sql.catalog.s3tables_catalog.rest.sigv4-enabled": "true",
+        "spark.sql.catalog.s3tables_catalog.rest.signing-name": "s3tables",
+        "spark.sql.catalog.s3tables_catalog.rest.signing-region": "us-west-2",
+    }
+
+
+def _wherobots_catalog_config():
+    return {
+        "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.iceberg_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+        "spark.sql.catalog.iceberg_catalog.warehouse": "s3://my-bucket/warehouse",
+    }
+
+
+class TestSelectIcebergConfNone:
+    def test_returns_empty_when_config_is_none(self):
+        assert _select_iceberg_conf(None, "GLUE") == {}
+        assert _select_iceberg_conf(None, "DATABRICKS") == {}
+        assert _select_iceberg_conf(None, "WHEROBOTS") == {}
+
+
+class TestSelectIcebergConfPrimaryOnly:
+    def test_glue_returns_spark_config(self):
+        cfg = IcebergConfig(spark_config=json.dumps(_rest_catalog_config()))
+        result = _select_iceberg_conf(cfg, "GLUE")
+        assert result == _rest_catalog_config()
+
+    def test_databricks_returns_spark_config(self):
+        cfg = IcebergConfig(spark_config=json.dumps(_rest_catalog_config()))
+        result = _select_iceberg_conf(cfg, "DATABRICKS")
+        assert result == _rest_catalog_config()
+
+    def test_wherobots_returns_wherobots_spark_config(self):
+        cfg = IcebergConfig(wherobots_spark_config=json.dumps(_wherobots_catalog_config()))
+        result = _select_iceberg_conf(cfg, "WHEROBOTS")
+        assert result == _wherobots_catalog_config()
+
+
+class TestSelectIcebergConfS3Tables:
+    def test_glue_merges_primary_and_s3tables(self):
+        cfg = IcebergConfig(
+            spark_config=json.dumps(_rest_catalog_config()),
+            s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+        )
+        result = _select_iceberg_conf(cfg, "GLUE")
+        # Both catalog configs present
+        assert "spark.sql.catalog.iceberg_catalog" in result
+        assert "spark.sql.catalog.s3tables_catalog" in result
+        assert result["spark.sql.catalog.s3tables_catalog.rest.signing-name"] == "s3tables"
+
+    def test_databricks_merges_primary_and_s3tables(self):
+        cfg = IcebergConfig(
+            spark_config=json.dumps(_rest_catalog_config()),
+            s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+        )
+        result = _select_iceberg_conf(cfg, "DATABRICKS")
+        assert "spark.sql.catalog.iceberg_catalog" in result
+        assert "spark.sql.catalog.s3tables_catalog" in result
+
+    def test_wherobots_merges_primary_and_s3tables(self):
+        wherobots_s3t = {
+            "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.s3tables_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+        }
+        cfg = IcebergConfig(
+            wherobots_spark_config=json.dumps(_wherobots_catalog_config()),
+            wherobots_s3tables_spark_config=json.dumps(wherobots_s3t),
+        )
+        result = _select_iceberg_conf(cfg, "WHEROBOTS")
+        assert "spark.sql.catalog.iceberg_catalog" in result
+        assert "spark.sql.catalog.s3tables_catalog" in result
+
+    def test_s3tables_only_without_primary(self):
+        cfg = IcebergConfig(
+            s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+        )
+        result = _select_iceberg_conf(cfg, "GLUE")
+        assert "spark.sql.catalog.s3tables_catalog" in result
+        assert "spark.sql.catalog.iceberg_catalog" not in result
+
+    def test_empty_s3tables_does_not_change_primary(self):
+        cfg = IcebergConfig(
+            spark_config=json.dumps(_rest_catalog_config()),
+            s3tables_spark_config="{}",
+        )
+        result = _select_iceberg_conf(cfg, "GLUE")
+        assert result == _rest_catalog_config()
+
+    def test_extra_spark_conf_still_wins_downstream(self):
+        """Verify that S3 Tables keys can still be overridden by extra_spark_conf
+        (tested at the handler level, not here — this confirms merge order)."""
+        cfg = IcebergConfig(
+            spark_config=json.dumps(_rest_catalog_config()),
+            s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+        )
+        result = _select_iceberg_conf(cfg, "GLUE")
+        # S3 Tables values are present as-is before extra_spark_conf is applied
+        assert result["spark.sql.catalog.s3tables_catalog.rest.signing-region"] == "us-west-2"

--- a/tests/test_select_iceberg_conf.py
+++ b/tests/test_select_iceberg_conf.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from overture_airflow_provider.config import IcebergConfig
 from overture_airflow_provider.spark_agnostic_taskgroup import _select_iceberg_conf
 
@@ -58,6 +60,21 @@ class TestSelectIcebergConfPrimaryOnly:
         cfg = IcebergConfig(wherobots_spark_config=json.dumps(_wherobots_catalog_config()))
         result = _select_iceberg_conf(cfg, "WHEROBOTS")
         assert result == _wherobots_catalog_config()
+
+    def test_invalid_json_identifies_field_name(self):
+        cfg = IcebergConfig(spark_config="{not-json")
+
+        with pytest.raises(ValueError, match=r"IcebergConfig\.spark_config"):
+            _select_iceberg_conf(cfg, "GLUE")
+
+    def test_non_object_json_identifies_field_name(self):
+        cfg = IcebergConfig(wherobots_s3tables_spark_config='["not", "a", "dict"]')
+
+        with pytest.raises(
+            ValueError,
+            match=r"IcebergConfig\.wherobots_s3tables_spark_config must decode to a JSON object",
+        ):
+            _select_iceberg_conf(cfg, "WHEROBOTS")
 
 
 class TestSelectIcebergConfS3Tables:


### PR DESCRIPTION
## Summary

Closes #9

Add `s3tables_spark_config` and `wherobots_s3tables_spark_config` fields to `IcebergConfig`, enabling a second Iceberg catalog (S3 Tables) to coexist alongside the primary catalog.

## Changes

- **`config.py`** — Two new JSON-string fields on `IcebergConfig` for S3 Tables catalog config (Glue/Databricks and Wherobots variants)
- **`spark_agnostic_taskgroup.py`** — Updated `_select_iceberg_conf()` to merge primary + S3 Tables configs; added `_load_json_config()` helper
- **`render.py`** — Updated Iceberg selection logic for consistency with runtime path
- **`AGENTS.md`** — Updated IcebergConfig documentation
- **`tests/test_select_iceberg_conf.py`** — 10 tests covering coexistence scenarios

## Usage

```python
iceberg_config=IcebergConfig(
    spark_config=json.dumps(get_iceberg_spark_config_rest()),
    s3tables_spark_config=json.dumps(get_iceberg_spark_config_s3tables()),
)
```

S3 Tables keys must be namespaced under a distinct catalog alias (e.g. `spark.sql.catalog.s3tables_catalog.*`) to avoid conflicts with the primary catalog.