### PR TITLE
[FEATURE] Add Sedona 1.8.x/1.9.x support

### DIFF
--- a/src/overture_airflow_provider/spark.py
+++ b/src/overture_airflow_provider/spark.py
@@ -74,6 +74,11 @@ class SparkSedona:
         # https://sedona.apache.org/latest-snapshot/setup/install-python/#prepare-sedona-spark-jar
         spark_major, spark_minor = py_spark_version.split(".")[:2]
         sedona_major, sedona_minor = sedona_version.split(".")[:2]
+        if int(sedona_major) == 1 and int(sedona_minor) >= 8 and int(spark_minor) <= 3:
+            raise RuntimeError(
+                f"Sedona {sedona_version} dropped Spark 3.3 support. "
+                "Use GLUE_v5 or another Spark 3.4+ implementation."
+            )
         if spark_major != "3":
             raise RuntimeError("I'm only supporting spark 3")
         if int(spark_minor) <= 3 and int(sedona_major) == 1 and int(sedona_minor) <= 6:
@@ -89,6 +94,8 @@ class SparkSedona:
             "1.7.0": "28.5",
             "1.7.1": "28.5",
             "1.7.2": "28.5",
+            "1.8.1": "33.1",
+            "1.9.0": "33.5",
         }
         return geotools_version_map[sedona_version]
 

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -76,11 +76,20 @@ class TestSparkSedonaVersionForSedona:
             ("3.4.1", "1.7.0", "3.4"),
             ("3.5.0", "1.7.0", "3.5"),
             ("3.5.2", "1.7.1", "3.5"),
+            ("3.3.0", "1.7.2", "3.3"),
+            ("3.4.1", "1.8.1", "3.4"),
+            ("3.5.2", "1.8.1", "3.5"),
+            ("3.5.2", "1.9.0", "3.5"),
         ],
     )
     def test_spark_version_for_sedona(self, spark_v, sedona_v, expected):
         result = SparkSedona.getSparkVersionForSedona(spark_v, sedona_v)
         assert result == expected
+
+    @pytest.mark.parametrize("sedona_v", ["1.8.1", "1.9.0"])
+    def test_sedona_1_8_plus_drops_spark_3_3(self, sedona_v):
+        with pytest.raises(RuntimeError, match="dropped Spark 3.3 support"):
+            SparkSedona.getSparkVersionForSedona("3.3.0", sedona_v)
 
     def test_non_spark3_raises(self):
         with pytest.raises(RuntimeError, match="only supporting spark 3"):
@@ -96,6 +105,8 @@ class TestSparkSedonaGeotoolsVersion:
             ("1.7.0", "28.5"),
             ("1.7.1", "28.5"),
             ("1.7.2", "28.5"),
+            ("1.8.1", "33.1"),
+            ("1.9.0", "33.5"),
         ],
     )
     def test_known_versions(self, sedona_v, expected_geotools):


### PR DESCRIPTION
## Summary

Brings `SparkSedona` in `src/overture_airflow_provider/spark.py` to parity with the newer downstream copy so it supports Sedona 1.8.x/1.9.x.

This is moving the [changes to add Sedona 1.8.x support in `tf-data-platform`](https://github.com/OvertureMaps/tf-data-platform/pull/3930) to be supported in the provider, unlocking the final migration of internal code to using this provider.

### Changes
- **`getSparkVersionForSedona`**: adds a guard before the existing logic. Sedona >= 1.8 dropped Spark 3.3 support, so calling it with Spark 3.3 now raises a clear `RuntimeError` directing users to GLUE_v5 or another Spark 3.4+ implementation. Legacy paths (Spark 3.3 with Sedona <= 1.7, the `<= 1.6` → `3.0` branch, and the non-Spark-3 guard) are unchanged.
- **`getGeotoolsWrapperVersion`**: adds `1.8.1` → `33.1` and `1.9.0` → `33.5`. Existing entries unchanged.

### Tests
Extended `tests/test_spark.py`:
- `1.8.1` / `1.9.0` with Spark 3.3 raise matching "dropped Spark 3.3 support"
- `3.4.1`/`3.5.2` with `1.8.1` → `3.4`/`3.5`; `3.5.2` with `1.9.0` → `3.5`
- `3.3.0` with `1.7.2` → `3.3` (legacy path unaffected)
- geotools map entries for `1.8.1`/`1.9.0` plus existing values

All checks green: `uv run pytest -v` (255 passed), `uv run ruff check .`, `uv run ruff format --check .`.

Closes #11
Refs OvertureMaps/tf-data-platform#3947