### PR TITLE
[CHORE] Remove Databricks v13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+
+- `DATABRICKS_v13` (`SparkImpl`): Databricks Runtime 13.3 LTS (Spark 3.4.1 / Python 3.10.6) dropped.
+
 ## [0.1.0] - Initial release
 
 - `spark_agnostic_task_group` and `spark_agnostic_mapped_task_group` public
   entry points.
-- Support for AWS Glue v4 / v5, Databricks 13.3 / 14.3 / 15.4, and Wherobots
+- Support for AWS Glue v4 / v5, Databricks 14.3 / 15.4 LTS, and Wherobots
   Cloud 1.5.0.
 - Typed config dataclasses: `PackageRegistryConfig`, `ArtifactStoreConfig`,
   `IcebergConfig`, `GlueConfig`, `DatabricksConfig`, `WherobotsConfig`.

--- a/README.md
+++ b/README.md
@@ -36,22 +36,22 @@ Requires Python `>=3.11` and Apache Airflow `>=2.11`.
 
 ### Provider requirements
 
-| | Minimum | Also tested |
-|---|---|---|
-| Python | 3.11 | 3.12, 3.13 |
-| Apache Airflow | 2.11 | 3.x |
+|                | Minimum | Also tested |
+| -------------- | ------- | ----------- |
+| Python         | 3.11    | 3.12, 3.13  |
+| Apache Airflow | 2.11    | 3.x         |
 
 ### Spark platform matrix
 
 Pass one of these names as `spark_impl_name`:
 
-| `spark_impl_name` | Platform | Spark | Scala | Python runtime |
-|---|---|---|---|---|
-| `GLUE_v4` | AWS Glue 4.0 | 3.3.0 | 2.12 | 3.10 |
-| `GLUE_v5` | AWS Glue 5.0 | 3.5.2 | 2.12 | 3.11 |
-| `DATABRICKS_v14` | Databricks Runtime 14.3 LTS | 3.5.0 | 2.12 | 3.10.12 |
-| `DATABRICKS_v15` | Databricks Runtime 15.4 LTS | 3.5.0 | 2.12 | 3.11.0 |
-| `WHEROBOTS_v1_5_0` | Wherobots Cloud 1.5.0 | 3.5.0 | 2.12 | 3.11 |
+| `spark_impl_name`  | Platform                    | Spark | Scala | Python runtime |
+| ------------------ | --------------------------- | ----- | ----- | -------------- |
+| `GLUE_v4`          | AWS Glue 4.0                | 3.3.0 | 2.12  | 3.10           |
+| `GLUE_v5`          | AWS Glue 5.0                | 3.5.2 | 2.12  | 3.11           |
+| `DATABRICKS_v14`   | Databricks Runtime 14.3 LTS | 3.5.0 | 2.12  | 3.10.12        |
+| `DATABRICKS_v15`   | Databricks Runtime 15.4 LTS | 3.5.0 | 2.12  | 3.11.0         |
+| `WHEROBOTS_v1_5_0` | Wherobots Cloud 1.5.0       | 3.5.0 | 2.12  | 3.11           |
 
 > `SYNAPSE_v3_3_1` / `SYNAPSE_v3_4_1` are defined but not yet active (Azure Synapse support reserved).
 
@@ -60,15 +60,15 @@ Pass one of these names as `spark_impl_name`:
 Sedona JARs are resolved from Maven Central at runtime. Tested pairings and the
 minimum Spark version required:
 
-| Sedona | geotools-wrapper | Min Spark |
-|---|---|---|
-| 1.5.3 | 28.2 | 3.3 |
-| 1.6.1 | 28.2 | 3.3 |
-| 1.7.0 | 28.5 | 3.3 |
-| 1.7.1 | 28.5 | 3.3 |
-| 1.7.2 | 28.5 | 3.3 |
-| 1.8.1 | 33.1 | 3.4 (Spark 3.3 dropped) |
-| 1.9.0 | 33.5 | 3.4 (Spark 3.3 dropped) |
+| Sedona | geotools-wrapper | Min Spark               |
+| ------ | ---------------- | ----------------------- |
+| 1.5.3  | 28.2             | 3.3                     |
+| 1.6.1  | 28.2             | 3.3                     |
+| 1.7.0  | 28.5             | 3.3                     |
+| 1.7.1  | 28.5             | 3.3                     |
+| 1.7.2  | 28.5             | 3.3                     |
+| 1.8.1  | 33.1             | 3.4 (Spark 3.3 dropped) |
+| 1.9.0  | 33.5             | 3.4 (Spark 3.3 dropped) |
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,44 @@ pip install "overture-airflow-provider[all]"
 
 Requires Python `>=3.11` and Apache Airflow `>=2.11`.
 
+## Supported versions
+
+### Provider requirements
+
+| | Minimum | Also tested |
+|---|---|---|
+| Python | 3.11 | 3.12, 3.13 |
+| Apache Airflow | 2.11 | 3.x |
+
+### Spark platform matrix
+
+Pass one of these names as `spark_impl_name`:
+
+| `spark_impl_name` | Platform | Spark | Scala | Python runtime |
+|---|---|---|---|---|
+| `GLUE_v4` | AWS Glue 4.0 | 3.3.0 | 2.12 | 3.10 |
+| `GLUE_v5` | AWS Glue 5.0 | 3.5.2 | 2.12 | 3.11 |
+| `DATABRICKS_v14` | Databricks Runtime 14.3 LTS | 3.5.0 | 2.12 | 3.10.12 |
+| `DATABRICKS_v15` | Databricks Runtime 15.4 LTS | 3.5.0 | 2.12 | 3.11.0 |
+| `WHEROBOTS_v1_5_0` | Wherobots Cloud 1.5.0 | 3.5.0 | 2.12 | 3.11 |
+
+> `SYNAPSE_v3_3_1` / `SYNAPSE_v3_4_1` are defined but not yet active (Azure Synapse support reserved).
+
+### Apache Sedona (optional)
+
+Sedona JARs are resolved from Maven Central at runtime. Tested pairings and the
+minimum Spark version required:
+
+| Sedona | geotools-wrapper | Min Spark |
+|---|---|---|
+| 1.5.3 | 28.2 | 3.3 |
+| 1.6.1 | 28.2 | 3.3 |
+| 1.7.0 | 28.5 | 3.3 |
+| 1.7.1 | 28.5 | 3.3 |
+| 1.7.2 | 28.5 | 3.3 |
+| 1.8.1 | 33.1 | 3.4 (Spark 3.3 dropped) |
+| 1.9.0 | 33.5 | 3.4 (Spark 3.3 dropped) |
+
 ## Quick start
 
 ```python
@@ -64,22 +102,17 @@ with DAG(
         parameters={"s3_input": "s3://example-bucket/in/", "s3_output": "s3://example-bucket/out/"},
         spark_cluster_size=AwsGlueClusterSize.G_2X.name,
         artifact_store=ArtifactStoreConfig(
-            s3_assets_bucket="example-bucket",
-            s3_assets_root="spark-agnostic-operator",
+            s3_bucket="example-bucket",
+            s3_root="spark-agnostic-operator",
         ),
         package_registry=PackageRegistryConfig(
-            codeartifact_domain="my-domain",
-            codeartifact_domain_owner="123456789012",
-            codeartifact_repository="my-pypi",
-            codeartifact_region="us-east-1",
+            domain="my-domain",
+            domain_owner="123456789012",
+            repository="my-pypi",
+            region="us-east-1",
         ),
-        glue=GlueConfig(iam_role_name="AWSGlueServiceRole"),
-        iceberg=IcebergConfig(
-            warehouse="my_catalog",
-            uri="https://glue.us-west-2.amazonaws.com/iceberg",
-            account_id="123456789012",
-            region="us-west-2",
-        ),
+        glue_config=GlueConfig(iam_role_name="AWSGlueServiceRole"),
+        iceberg_config=IcebergConfig(spark_config="{}"),
     )
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@ Expose a **single Airflow task group** that runs a Spark job (PySpark or Scala)
 on one of:
 
 - AWS Glue (v4 or v5)
-- Databricks (13.3 / 14.3 / 15.4 LTS)
+- Databricks (14.3 / 15.4 LTS)
 - Wherobots Cloud (1.5.0)
 
 …with the same caller-facing API. The DAG code does not change when the engine

--- a/src/overture_airflow_provider/spark.py
+++ b/src/overture_airflow_provider/spark.py
@@ -23,9 +23,6 @@ class SparkImpl(Enum):
     # We do not support Spark < 3.3 — too many ecosystem issues.
     GLUE_v4 = SparkPlatform(SparkFamily.GLUE, "4.0", "3.3.0", "2.12", "3.10")
     GLUE_v5 = SparkPlatform(SparkFamily.GLUE, "5.0", "3.5.2", "2.12", "3.11")
-    DATABRICKS_v13 = SparkPlatform(
-        SparkFamily.DATABRICKS, "13.3.x-scala2.12", "3.4.1", "2.12", "3.10.6"
-    )
     DATABRICKS_v14 = SparkPlatform(
         SparkFamily.DATABRICKS, "14.3.x-scala2.12", "3.5.0", "2.12", "3.10.12"
     )

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -37,7 +37,6 @@ class TestSparkImplMetadata:
         [
             (SparkImpl.GLUE_v4, "3.3.0"),
             (SparkImpl.GLUE_v5, "3.5.2"),
-            (SparkImpl.DATABRICKS_v13, "3.4.1"),
             (SparkImpl.DATABRICKS_v14, "3.5.0"),
             (SparkImpl.DATABRICKS_v15, "3.5.0"),
             (SparkImpl.WHEROBOTS_v1_5_0, "3.5.0"),


### PR DESCRIPTION
Removes the \DATABRICKS_v13\ \SparkImpl\ entry (\13.3.x-scala2.12\ / Spark 3.4.1) and its test parametrize case.

Closes #14