### PR TITLE
[CHORE] Publish package to PyPI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   ruff:
     name: Ruff lint and format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read  # checkout only
     steps:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,68 @@
+---
+# Publishes the overture-airflow-provider package in two scenarios:
+#   1. Release (production): triggered when a GitHub Release is published → publishes to PyPI.
+#   2. Dry-run: triggered manually via workflow_dispatch → publishes to Test PyPI to verify
+#      the build and publish pipeline end-to-end without affecting the production package index.
+# Uses OIDC trusted publishing — no API token required.
+name: Publish overture-airflow-provider
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Target '${{ github.event_name == 'workflow_dispatch' && 'Test PyPI' || 'PyPI' }}'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'test-pypi' || 'pypi' }}
+    env:
+      TEST_PYPI_URL: https://test.pypi.org/legacy/
+    permissions:
+      id-token: write # OIDC — required for PyPI trusted publishing
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: ${{ github.event_name == 'workflow_dispatch' && env.TEST_PYPI_URL || '' }}
+          skip-existing: ${{ github.event_name == 'workflow_dispatch' }}
+          attestations: true
+          verbose: false

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:
@@ -32,7 +32,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Build package
         run: uv build
@@ -46,7 +46,7 @@ jobs:
   publish:
     name: Target '${{ github.event_name == 'workflow_dispatch' && 'Test PyPI' || 'PyPI' }}'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: ${{ github.event_name == 'workflow_dispatch' && 'test-pypi' || 'pypi' }}
     env:
       TEST_PYPI_URL: https://test.pypi.org/legacy/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pytest:
     name: pytest (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read  # checkout only
     strategy:
@@ -44,7 +44,7 @@ jobs:
 
   all-pass:
     name: All pytest versions passed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: pytest
     if: always()
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,38 @@ Use `[WIP]` as a prefix on repos without draft PR support.
 - Live-platform E2E tests are tracked separately and require CI credentials.
   PRs adding them go into `tests/e2e/`.
 
+## Publishing
+
+Package published to [PyPI](https://pypi.org/project/overture-airflow-provider/) via the
+[`publish-pypi.yml`](.github/workflows/publish-pypi.yml) workflow using
+[OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) — no API token needed.
+This repo, workflow, and GitHub environment must be pre-configured in PyPI and Test PyPI.
+
+### Releasing a new version
+
+1. Update `version` in `pyproject.toml` (`project.version`).
+2. Commit and merge to `main`.
+3. Create a GitHub Release (tag + title + notes).
+4. The `publish-pypi.yml` workflow triggers automatically and publishes to PyPI
+   in the [`pypi` GitHub environment](https://github.com/OvertureMaps/overture-airflow-provider/deployments).
+
+### Dry-run / Test PyPI
+
+Trigger the workflow manually via `workflow_dispatch` to publish to
+[Test PyPI](https://test.pypi.org/project/overture-airflow-provider/) instead of production.
+Useful for verifying the build and publish pipeline end-to-end. Uses `skip-existing: true`
+so version conflicts don't fail the run.
+
+### Environments
+
+| GitHub environment | Target index    | Trigger                       |
+|--------------------|-----------------|-------------------------------|
+| `pypi`             | PyPI (prod)     | GitHub Release published      |
+| `test-pypi`        | Test PyPI       | Manual `workflow_dispatch`    |
+
+Both environments use OIDC trusted publisher entries on their respective indexes —
+no secrets or API tokens stored in the repository.
+
 ## Reporting bugs
 
 Open an issue with:


### PR DESCRIPTION
Closes #16

## What

- Adds `.github/workflows/publish-pypi.yml` — OIDC trusted publishing, no API token stored
- Updates `CONTRIBUTING.md` with a Publishing section documenting the release process

## How it works

| Trigger | Target |
|---------|--------|
| GitHub Release published | PyPI (production), via `pypi` environment |
| Manual `workflow_dispatch` | Test PyPI, via `test-pypi` environment |

Mirrors the approach in [`overturemaps-py`](https://github.com/OvertureMaps/overturemaps-py/blob/main/.github/workflows/publish-pypi.yml).

## Prerequisites (one-time, outside this PR)

PyPI and Test PyPI need OIDC trusted publisher entries configured for this repo + workflow + environment before the workflow will succeed. See [PyPI trusted publishing docs](https://docs.pypi.org/trusted-publishers/).