### PR TITLE
[BUG](glue) Use no-op Scala stub for Glue scriptLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-02
+
+### Fixed
+
+- **Glue Scala jobs (regression):** The `scriptLocation` stub uploaded to S3 for
+  Scala jobs was a real Scala program (`object JobRunnerGlue`, importing
+  `com.amazonaws.services.glue.*` and `scala.jdk.CollectionConverters._`). AWS
+  Glue compiles that file before every run — even when the real entry point is
+  a precompiled JAR selected via `--class` / `--extra-jars` — and the file
+  failed to compile on Glue 5.0 (Scala 2.12.18), killing jobs ~20 s after
+  submission. Replaced with a comment-only no-op stub (zero compile surface),
+  restoring the proven pre-migration behaviour. The reflective
+  `run(spark, params)` dispatch was dead code in all current code paths and has
+  been removed. ([#18](https://github.com/OvertureMaps/overture-airflow-provider/pull/18))
+
 ### Removed
 
 - `DATABRICKS_v13` (`SparkImpl`): Databricks Runtime 13.3 LTS (Spark 3.4.1 / Python 3.10.6) dropped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "overture-airflow-provider"
-version = "0.1.0"
+version = "0.1.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_glue.py
+++ b/src/overture_airflow_provider/_glue.py
@@ -13,6 +13,18 @@ from overture_airflow_provider.spark_agnostic_helpers import SparkAgnosticHelper
 
 MAX_TIMEOUT_HOURS = 8
 
+# Keys excluded from the Glue Scala --conf DefaultArgument.
+# spark.jars.packages: Glue can't resolve Maven coords at runtime; JARs are pre-staged via --extra-jars.
+# spark.driver/executor.extraJavaOptions: already set via --driver-java-options / --executor-java-options;
+#   duplicating them in --conf would override those args and lose the sedona charset setting.
+_GLUE_SCALA_CONF_EXCLUDE = frozenset(
+    {
+        "spark.jars.packages",
+        "spark.driver.extraJavaOptions",
+        "spark.executor.extraJavaOptions",
+    }
+)
+
 
 def _build_agnostic_xcom_payload(setup_info: dict, *, job_url: str) -> str:
     return json.dumps(
@@ -284,6 +296,16 @@ def build_glue_operator_kwargs(
         glue_job_default_args = {
             k: v for k, v in glue_job_default_args.items() if v is not None and v != ""
         }
+        # Inject Iceberg / Spark conf into DefaultArguments as Glue's native --conf mechanism.
+        # Glue applies this at session-creation time, before any user code runs, so the catalog
+        # is registered even though the real entry point is the caller's --class in --extra-jars.
+        # Format: "k1=v1 --conf k2=v2 ..." (combined with the "--conf" key itself by Glue).
+        scala_spark_conf = {
+            k: v for k, v in spark_conf_dict.items() if k not in _GLUE_SCALA_CONF_EXCLUDE
+        }
+        if scala_spark_conf:
+            entries = [f"{k}={v}" for k, v in scala_spark_conf.items()]
+            glue_job_default_args["--conf"] = " --conf ".join(entries)
         parsed_params = (
             json.loads(setup_info["parameters"])
             if isinstance(setup_info["parameters"], str)

--- a/src/overture_airflow_provider/runners/__init__.py
+++ b/src/overture_airflow_provider/runners/__init__.py
@@ -6,55 +6,28 @@ runtime, the Python standard library, and dynamically-imported user job classes.
 
 ``SCALA_RUNNER_SOURCE`` is embedded here as a string so it is available as
 package data regardless of build-backend non-Python file inclusion policy.
+
+It is a deliberate comment-only no-op stub: AWS Glue Scala jobs run a
+precompiled JAR selected via the ``--class`` job parameter (passed through
+``--extra-jars``), so this ``scriptLocation`` file is never executed. Glue still
+*compiles* it before the job starts, so it only needs to compile cleanly. See
+the stub comment below for the full rationale.
 """
 
 SCALA_RUNNER_SOURCE: str = """\
-import com.amazonaws.services.glue.GlueContext
-import com.amazonaws.services.glue.util.GlueArgParser
-import org.apache.spark.SparkContext
-import scala.jdk.CollectionConverters._
-
-/**
- * Thin AWS Glue entry point for Scala jobs.
- *
- * Expected Glue job args (set via --default_arguments):
- *   --class_name       Fully-qualified class name to instantiate.
- *   --params           JSON-encoded parameter string forwarded to run().
- *   --extra_spark_conf JSON-encoded map of additional SparkConf key/value pairs.
- *
- * The target class must expose a zero-argument constructor and one of:
- *   - run(spark: SparkSession, params: String): Unit  (preferred)
- *   - run(params: String): Unit                       (legacy)
- */
-object JobRunnerGlue {
-  def main(args: Array[String]): Unit = {
-    val resolvedArgs = GlueArgParser
-      .getResolvedOptions(args, Array("class_name", "params", "extra_spark_conf"))
-      .asScala
-
-    val className = resolvedArgs.getOrElse("class_name", "")
-    val params    = resolvedArgs.getOrElse("params", "{}")
-
-    val sc      = new SparkContext()
-    val glueCtx = new GlueContext(sc)
-    val spark   = glueCtx.getSparkSession
-
-    val clazz    = Class.forName(className)
-    val instance = clazz.getDeclaredConstructor().newInstance()
-
-    // Prefer run(SparkSession, String); fall back to run(String).
-    try {
-      val m = clazz.getMethod(
-        "run",
-        classOf[org.apache.spark.sql.SparkSession],
-        classOf[String],
-      )
-      m.invoke(instance, spark, params)
-    } catch {
-      case _: NoSuchMethodException =>
-        val m = clazz.getMethod("run", classOf[String])
-        m.invoke(instance, params)
-    }
-  }
-}
+// Placeholder Scala script for AWS Glue Spark jobs - intentionally a no-op.
+//
+// AWS Glue requires a scriptLocation for every Scala job and COMPILES it before
+// the job runs, even when the real entry point is overridden via the `--class`
+// job parameter pointing at a class inside `--extra-jars`. Our Scala jobs ship
+// their logic in a precompiled JAR (passed via --extra-jars) and select the main
+// class with `--class`, so this file only needs to compile cleanly - it is never
+// executed.
+//
+// Keep this trivial: do NOT add imports or logic. Anything that fails to compile
+// on the Glue runtime's Scala version (e.g. Glue 5.0 = Scala 2.12) fails the whole
+// job before the JAR's `--class` main ever runs.
+//
+// AWS Glue job parameters (--class, --scriptLocation, --job-language, --extra-jars):
+// https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html
 """

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -353,6 +353,98 @@ class TestGlueExecuteJob:
         assert payload["job_url"].endswith("/run/jr_early123")
         assert payload["status"] == "RUNNING"
 
+    # ------------------------------------------------------------------
+    # Scala --conf injection (Iceberg catalog registration)
+    # ------------------------------------------------------------------
+
+    def test_scala_iceberg_conf_injected_into_default_args(self):
+        # Iceberg catalog conf must land in DefaultArguments["--conf"] so Glue
+        # applies it at session-creation time before any user code runs.
+        iceberg_conf = {
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.iceberg_catalog.catalog-impl": "org.apache.iceberg.rest.RESTCatalog",
+            "spark.sql.catalog.iceberg_catalog.uri": "https://glue.us-west-2.amazonaws.com/iceberg",
+        }
+        _, captured = self._run_glue(
+            module_name="", class_name="com.example.Main", extra_spark_conf=iceberg_conf
+        )
+        default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
+        assert "--conf" in default_args
+        conf_str = default_args["--conf"]
+        assert "spark.sql.catalog.iceberg_catalog=org.apache.iceberg.spark.SparkCatalog" in conf_str
+        assert (
+            "spark.sql.catalog.iceberg_catalog.catalog-impl=org.apache.iceberg.rest.RESTCatalog"
+            in conf_str
+        )
+        assert (
+            "spark.sql.catalog.iceberg_catalog.uri=https://glue.us-west-2.amazonaws.com/iceberg"
+            in conf_str
+        )
+
+    def test_scala_conf_format_uses_glue_delimiter(self):
+        # Multi-conf string must use " --conf " as delimiter so Glue parses it correctly.
+        iceberg_conf = {
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.iceberg_catalog.type": "rest",
+        }
+        _, captured = self._run_glue(
+            module_name="", class_name="com.example.Main", extra_spark_conf=iceberg_conf
+        )
+        conf_str = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]["--conf"]
+        # Two entries → exactly one " --conf " delimiter between them.
+        # The jar_info["sedona_packages"] key (spark.jars.packages) is excluded, so the
+        # only entries are the two iceberg_conf keys + any non-excluded platform defaults.
+        entries = conf_str.split(" --conf ")
+        assert len(entries) >= 2, "Expected at least two --conf entries for a multi-key conf"
+        for entry in entries:
+            assert "=" in entry, f"conf entry missing '=': {entry!r}"
+
+    def test_scala_conf_excludes_spark_jars_packages(self):
+        # spark.jars.packages must not appear in --conf: Glue can't resolve Maven coords
+        # at runtime; JARs are pre-staged via --extra-jars.
+        _, captured = self._run_glue(module_name="", class_name="com.example.Main")
+        default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
+        if "--conf" in default_args:
+            assert "spark.jars.packages" not in default_args["--conf"]
+
+    def test_scala_conf_excludes_java_options(self):
+        # driver/executor extraJavaOptions are handled by --driver-java-options /
+        # --executor-java-options; duplicating them in --conf would override those args
+        # and lose the sedona charset setting.
+        conf_with_java_opts = {
+            "spark.driver.extraJavaOptions": "-Dfoo=bar",
+            "spark.executor.extraJavaOptions": "-Dfoo=bar",
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        }
+        _, captured = self._run_glue(
+            module_name="", class_name="com.example.Main", extra_spark_conf=conf_with_java_opts
+        )
+        conf_str = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]["--conf"]
+        assert "spark.driver.extraJavaOptions" not in conf_str
+        assert "spark.executor.extraJavaOptions" not in conf_str
+        # The iceberg key must still be present.
+        assert "spark.sql.catalog.iceberg_catalog" in conf_str
+
+    def test_scala_conf_no_conf_key_when_only_excluded_keys(self):
+        # When extra_spark_conf is empty (only spark.jars.packages from jar_info is in
+        # spark_conf_dict), there is nothing to inject and --conf must not be added at all.
+        _, captured = self._run_glue(
+            module_name="", class_name="com.example.Main", extra_spark_conf={}
+        )
+        default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
+        # spark.jars.packages is excluded; if platform defaults also end up excluded,
+        # --conf should be absent. Assert it's either absent OR, if platform defaults
+        # contributed conf, they are present but jars.packages is not.
+        if "--conf" in default_args:
+            assert "spark.jars.packages" not in default_args["--conf"]
+
+    def test_pyspark_job_does_not_add_conf_to_default_args(self):
+        # PySpark runner reads --extra_spark_conf itself; Glue-level --conf is not needed
+        # and must not appear for PySpark jobs.
+        _, captured = self._run_glue(module_name="my_module", class_name="MyClass")
+        default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
+        assert "--conf" not in default_args
+
 
 class TestGetGlueJobUrlAndStatus:
     def _make_operator(self, job_state):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -219,6 +219,46 @@ def test_render_rejects_invalid_iceberg_json(spark_impl_name, iceberg_config, ex
         )
 
 
+_SCALA_KWARGS = dict(
+    module_name="",
+    class_name="com.example.Main",
+    parameters={"date": "2024-01-01"},
+    job_name="snapshot",
+)
+
+
+def test_render_glue_scala_emits_conf_in_default_args():
+    """Glue Scala render must include Iceberg catalog conf in DefaultArguments['--conf']."""
+    result = render_spark_job(
+        spark_impl_name="GLUE_v5",
+        iceberg_config=IcebergConfig(
+            spark_config=json.dumps(_rest_catalog_config()),
+            s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
+        ),
+        **_SCALA_KWARGS,
+    )
+    default_args = result.submit_payload["create_job_kwargs"]["DefaultArguments"]
+    assert "--conf" in default_args, "Glue Scala job must inject Iceberg conf via --conf"
+    conf_str = default_args["--conf"]
+    assert "spark.sql.catalog.iceberg_catalog=org.apache.iceberg.spark.SparkCatalog" in conf_str
+    assert "spark.sql.catalog.s3tables_catalog" in conf_str
+    # Excluded keys must not appear.
+    assert "spark.jars.packages" not in conf_str
+    assert "spark.driver.extraJavaOptions" not in conf_str
+    assert "spark.executor.extraJavaOptions" not in conf_str
+
+
+def test_render_glue_pyspark_no_conf_in_default_args():
+    """Glue PySpark render must NOT add --conf to DefaultArguments."""
+    result = render_spark_job(
+        spark_impl_name="GLUE_v5",
+        iceberg_config=IcebergConfig(spark_config=json.dumps(_rest_catalog_config())),
+        **_COMMON_KWARGS,
+    )
+    default_args = result.submit_payload["create_job_kwargs"]["DefaultArguments"]
+    assert "--conf" not in default_args, "PySpark Glue job must not add --conf to DefaultArguments"
+
+
 def test_render_write_to_creates_files(tmp_path):
     result = render_spark_job(spark_impl_name="GLUE_v5", **_COMMON_KWARGS)
     written = result.write_to(str(tmp_path))

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -42,8 +42,9 @@ def test_get_runner_path_glue_scala():
     try:
         assert p.exists()
         content = p.read_text(encoding="utf-8")
-        assert "JobRunnerGlue" in content
-        assert "SparkSession" in content
+        # Comment-only no-op stub: every line is a Scala comment.
+        assert content.lstrip().startswith("//")
+        assert "import " not in content
     finally:
         p.unlink(missing_ok=True)
 
@@ -119,10 +120,18 @@ def test_scala_runner_source_is_str():
     assert len(SCALA_RUNNER_SOURCE) > 0
 
 
-def test_scala_runner_source_contains_expected_symbols():
-    assert "JobRunnerGlue" in SCALA_RUNNER_SOURCE
-    assert "GlueArgParser" in SCALA_RUNNER_SOURCE
-    assert "SparkSession" in SCALA_RUNNER_SOURCE
+def test_scala_runner_source_is_comment_only_stub():
+    # Glue compiles the scriptLocation before the job runs even though the real
+    # entry point is selected via --class inside --extra-jars. The stub must
+    # have zero compile surface: every non-blank line is a Scala comment.
+    for line in SCALA_RUNNER_SOURCE.splitlines():
+        stripped = line.strip()
+        if stripped:
+            assert stripped.startswith("//"), f"non-comment line in stub: {line!r}"
+
+
+def test_scala_runner_source_documents_aws_reference():
+    assert "https://docs.aws.amazon.com/glue/" in SCALA_RUNNER_SOURCE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two production AWS Glue bugs for Scala jobs.

Fixes #20
Tracked by #19

## Bug 1: scriptLocation compile failure (Glue 5.0 regression)

AWS Glue requires a `scriptLocation` file for **every** Scala job and **always compiles that file before the job runs** -- even when the real entry point is overridden via the `--class` job parameter pointing at a class inside `--extra-jars`.

Consumers (e.g. tf-data-platform's `corpus_data_export` DAG) run a precompiled JAR: they submit `--class org.overturemaps.store.JobRunner` with the corpus jar in `--extra-jars`. So the `scriptLocation` file's own code is **never executed** -- `--class` always overrides it.

The provider was uploading a *real* Scala program as that `scriptLocation`: `SCALA_RUNNER_SOURCE` defined `object JobRunnerGlue` and imported `com.amazonaws.services.glue.*` and `scala.jdk.CollectionConverters._`. Because Glue compiles it on the Glue 5.0 runtime (Scala 2.12.18), this dead-but-compiled file failed to compile there and killed the whole job ~20s in -- before the corpus jar's `--class` main ever ran. The pre-migration implementation used an empty/comment-only `.scala` stub, which always compiled trivially; that is the behavior this PR restores.

**Fix:** Replace `SCALA_RUNNER_SOURCE` with a **comment-only no-op stub** -- no imports, no `object`/`class`, zero compile surface. It includes the rationale plus a link to the [AWS Glue job parameters docs](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html).

## Bug 2: Iceberg catalog not registered for Glue Scala jobs

For Glue Scala jobs the provider passes Iceberg/Spark conf as `--extraSparkConf` in the job's script args, intending the caller's JAR to pick it up. But the precompiled corpus JAR (`org.overturemaps.store.JobRunner`) does not read that argument, so the Iceberg catalog (e.g. `iceberg_catalog`) is never registered in the Spark session. Any query referencing it fails with:

```
AnalysisException: [REQUIRES_SINGLE_PART_NAMESPACE] spark_catalog requires
a single-part namespace, but got `iceberg_catalog`.`geocodes`.
```

The PySpark runner reads `--extra_spark_conf` and applies it before user code runs, so PySpark jobs were unaffected.

**Fix:** Inject the filtered Spark conf into `DefaultArguments["--conf"]` using Glue's native `--conf` mechanism. Glue applies this string to the Spark session at framework-creation time, before any user code runs, so the catalog is registered regardless of which `--class` entry point executes.

Three keys are excluded from `--conf`:
- `spark.jars.packages`: Glue cannot resolve Maven coords at runtime; JARs are pre-staged via `--extra-jars`.
- `spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions`: already set via Glue's `--driver-java-options` / `--executor-java-options` args (which include `-Dsedona.global.charset=utf8`); overwriting them via `--conf` would lose that flag.

## Files changed

- `src/overture_airflow_provider/runners/__init__.py` -- comment-only Scala stub
- `src/overture_airflow_provider/_glue.py` -- `--conf` injection for Scala path
- `tests/test_runners.py` -- stub assertions
- `tests/test_platform_handlers.py` -- 6 new tests for `--conf` injection, exclusions, PySpark isolation
- `tests/test_render.py` -- 2 new end-to-end render tests (Scala has `--conf`, PySpark does not)
- `pyproject.toml` -- version 0.1.1
- `CHANGELOG.md` -- [0.1.1] entry

## Verification

- `uv run pytest` -- **263 passed**
- `uv run ruff check .` -- clean; `uv run ruff format` -- no changes

## Release note

Version bumped to `0.1.1` in this PR. After merge: tag the release, publish to PyPI, then bump the tf-data-platform pin from `overture-airflow-provider==0.1.0` to `==0.1.1`.