### PR TITLE
[BUG] Improve error message when WherobotsConfig.role_arn missing with Iceberg

### DIFF
--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -259,7 +259,10 @@ def build_wherobots_operator_kwargs(
 
     if "spark.sql.defaultCatalog" in spark_configs:
         if not wherobots_role_arn:
-            raise ValueError("wherobots_role_arn is required when using Iceberg with Wherobots.")
+            raise ValueError(
+                "WherobotsConfig.role_arn is required when using Iceberg with Wherobots. "
+                'Set it via: WherobotsConfig(role_arn="arn:aws:iam::<account>:role/<role-name>", ...)'
+            )
         catalog_name = spark_configs["spark.sql.defaultCatalog"]
         spark_configs.update(
             {


### PR DESCRIPTION
Fixes #21

## What

Clarify `ValueError` raised when `role_arn` is missing from `WherobotsConfig` while using Iceberg.

**Before:**
```
ValueError: wherobots_role_arn is required when using Iceberg with Wherobots.
```

**After:**
```
ValueError: WherobotsConfig.role_arn is required when using Iceberg with Wherobots.
Set it via: WherobotsConfig(role_arn="arn:aws:iam::<account>:role/<role-name>", ...)
```

## Why

Previous message leaked internal parameter name (`wherobots_role_arn`) instead of the public API field (`WherobotsConfig.role_arn`), and gave no hint on how to fix it.