### PR TITLE
[BUG](glue) Inject Iceberg catalog conf into --conf for PySpark Glue jobs

### DIFF
--- a/src/overture_airflow_provider/_glue.py
+++ b/src/overture_airflow_provider/_glue.py
@@ -26,6 +26,20 @@ _GLUE_SCALA_CONF_EXCLUDE = frozenset(
 )
 
 
+def _conf_default_arg(spark_conf_dict: dict) -> str | None:
+    """Build Glue's native ``--conf`` DefaultArgument string from a Spark conf dict.
+
+    Excludes keys Glue can't honor at session-creation time (Maven coords, java
+    options). Returns ``None`` when nothing is left to inject. Used by both the
+    Scala and PySpark paths so catalogs/extensions register identically at
+    SparkSession bootstrap.
+    """
+    filtered = {k: v for k, v in spark_conf_dict.items() if k not in _GLUE_SCALA_CONF_EXCLUDE}
+    if not filtered:
+        return None
+    return " --conf ".join(f"{k}={v}" for k, v in filtered.items())
+
+
 def _build_agnostic_xcom_payload(setup_info: dict, *, job_url: str) -> str:
     return json.dumps(
         {
@@ -278,6 +292,14 @@ def build_glue_operator_kwargs(
     }
 
     if module_name:
+        # Inject Iceberg / Spark conf into DefaultArguments as Glue's native --conf so the
+        # catalogs/extensions register at SparkSession bootstrap, before user code runs.
+        # Glue (not the runner) builds the session for PySpark jobs too, so legacy
+        # SparkSedonaJob.run() implementations that don't accept a `spark` kwarg still get
+        # the named catalogs. --extra_spark_conf is kept as the documented runner contract.
+        conf_arg = _conf_default_arg(spark_conf_dict)
+        if conf_arg:
+            glue_job_default_args["--conf"] = conf_arg
         script_args = {
             "--module_name": module_name,
             "--class_name": class_name,
@@ -300,12 +322,9 @@ def build_glue_operator_kwargs(
         # Glue applies this at session-creation time, before any user code runs, so the catalog
         # is registered even though the real entry point is the caller's --class in --extra-jars.
         # Format: "k1=v1 --conf k2=v2 ..." (combined with the "--conf" key itself by Glue).
-        scala_spark_conf = {
-            k: v for k, v in spark_conf_dict.items() if k not in _GLUE_SCALA_CONF_EXCLUDE
-        }
-        if scala_spark_conf:
-            entries = [f"{k}={v}" for k, v in scala_spark_conf.items()]
-            glue_job_default_args["--conf"] = " --conf ".join(entries)
+        conf_arg = _conf_default_arg(spark_conf_dict)
+        if conf_arg:
+            glue_job_default_args["--conf"] = conf_arg
         parsed_params = (
             json.loads(setup_info["parameters"])
             if isinstance(setup_info["parameters"], str)

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -438,12 +438,33 @@ class TestGlueExecuteJob:
         if "--conf" in default_args:
             assert "spark.jars.packages" not in default_args["--conf"]
 
-    def test_pyspark_job_does_not_add_conf_to_default_args(self):
-        # PySpark runner reads --extra_spark_conf itself; Glue-level --conf is not needed
-        # and must not appear for PySpark jobs.
+    def test_pyspark_iceberg_conf_injected_into_default_args(self):
+        # PySpark jobs must also register catalogs at SparkSession bootstrap via Glue's
+        # native --conf. Glue builds the session before user code runs, so legacy
+        # SparkSedonaJob.run() implementations without a `spark` kwarg still get catalogs.
+        iceberg_conf = {
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        }
+        _, captured = self._run_glue(
+            module_name="my_module", class_name="MyClass", extra_spark_conf=iceberg_conf
+        )
+        default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
+        assert "--conf" in default_args
+        conf_str = default_args["--conf"]
+        assert "spark.sql.catalog.iceberg_catalog=org.apache.iceberg.spark.SparkCatalog" in conf_str
+        assert (
+            "spark.sql.catalog.s3tables_catalog=org.apache.iceberg.spark.SparkCatalog" in conf_str
+        )
+        # Maven coords can't be resolved at runtime; JARs are pre-staged via --extra-jars.
+        assert "spark.jars.packages" not in conf_str
+
+    def test_pyspark_no_conf_key_when_only_excluded_keys(self):
+        # With no extra conf, only the excluded spark.jars.packages remains → no --conf.
         _, captured = self._run_glue(module_name="my_module", class_name="MyClass")
         default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
-        assert "--conf" not in default_args
+        if "--conf" in default_args:
+            assert "spark.jars.packages" not in default_args["--conf"]
 
 
 class TestGetGlueJobUrlAndStatus:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -248,15 +248,23 @@ def test_render_glue_scala_emits_conf_in_default_args():
     assert "spark.executor.extraJavaOptions" not in conf_str
 
 
-def test_render_glue_pyspark_no_conf_in_default_args():
-    """Glue PySpark render must NOT add --conf to DefaultArguments."""
+def test_render_glue_pyspark_emits_conf_in_default_args():
+    """Glue PySpark render must inject Iceberg catalog conf via DefaultArguments['--conf'].
+
+    Glue builds the SparkSession before user code runs, so catalogs must be registered at
+    bootstrap (matching the Scala path) — otherwise legacy SparkSedonaJob.run() classes that
+    don't accept a `spark` kwarg hit a catalog namespace error.
+    """
     result = render_spark_job(
         spark_impl_name="GLUE_v5",
         iceberg_config=IcebergConfig(spark_config=json.dumps(_rest_catalog_config())),
         **_COMMON_KWARGS,
     )
     default_args = result.submit_payload["create_job_kwargs"]["DefaultArguments"]
-    assert "--conf" not in default_args, "PySpark Glue job must not add --conf to DefaultArguments"
+    assert "--conf" in default_args, "PySpark Glue job must inject Iceberg conf via --conf"
+    conf_str = default_args["--conf"]
+    assert "spark.sql.catalog.iceberg_catalog=org.apache.iceberg.spark.SparkCatalog" in conf_str
+    assert "spark.jars.packages" not in conf_str
 
 
 def test_render_write_to_creates_files(tmp_path):


### PR DESCRIPTION
## Problem

Glue **PySpark** jobs fail with a "catalog namespace error" when accessing `iceberg_catalog` or `s3tables_catalog`, while **Scala** jobs on the same catalogs work fine.

### Root cause: Scala-vs-Python delivery asymmetry

In the GlueJobOperator kwargs assembly (`_glue.py`), `spark_conf_dict` carries the Iceberg catalog config (`spark.sql.catalog.iceberg_catalog.*`, `spark.sql.catalog.s3tables_catalog.*`, `spark.sql.extensions`, …).

- **Scala branch** injects this conf into `DefaultArguments["--conf"]` — Glue's native mechanism, applied at SparkSession **creation time, before user code runs**. Named catalogs exist → works.
- **PySpark branch** passed the conf **only** as the `--extra_spark_conf` script arg. That is consumed by `runners/job_runner_glue.py` and applied at **runtime** via `spark.conf.set()` — and only when the job's `run()` accepts a `spark` kwarg. Legacy `SparkSedonaJob` subclasses (e.g. `PlacesEmbedJob`) have `run(self, params)` with no `spark` param, so the conf was dropped entirely. Catalogs never defined → namespace error.

## Fix

The PySpark branch now also populates `DefaultArguments["--conf"]` with the same native injection the Scala branch uses, so catalogs/extensions register at session bootstrap for Python jobs too — including legacy `SparkSedonaJob` classes whose `run()` doesn't take a `spark` kwarg.

- Factored the conf→`--conf`-string logic into a shared `_conf_default_arg()` helper so Scala and Python behave identically.
- `--extra_spark_conf` is still passed unchanged (documented runner contract; still used by `spark`-kwarg jobs).
- Same exclude set applies: `spark.jars.packages` stays out of `--conf` (Glue can't resolve Maven coords at runtime; JARs are pre-staged via `--extra-jars`), as do `spark.driver/executor.extraJavaOptions`.

## Verify

- `uv run pytest` → **264 passed**.
- `uv run ruff check .` / `ruff format` → clean.
- Updated the two tests that encoded the old behavior (`test_render_glue_pyspark_*`, PySpark handler test) and added focused assertions that the Python branch emits `DefaultArguments["--conf"]` containing the iceberg/s3tables catalog keys while excluding `spark.jars.packages`.

Closes #24