### PR TITLE
[BUG] Render IcebergConfig Jinja via task op_kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "overture-airflow-provider"
-version = "0.1.3"
+version = "0.1.4"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -137,6 +137,11 @@ class IcebergConfig:
     platform family and merges them together. Pass only the variants you need;
     omit ``iceberg_config`` entirely for jobs that do not use Iceberg.
 
+    All four JSON config fields are forwarded to the task as ``op_kwargs``
+    strings, so Airflow Jinja in them (e.g. a warehouse ARN ending in
+    ``:bucket/{{ var.value.managed_bucket_iceberg }}``) is rendered at task
+    execution time — no need to resolve Variables before constructing this.
+
     Args:
         spark_config: Iceberg Spark config JSON string for Glue/Databricks.
             Defaults to ``"{}"`` (no Iceberg).

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -35,9 +35,12 @@ function, so standard Jinja syntax works without any manual rendering::
         ...
     )
 
-Config dataclasses (``IcebergConfig``, ``WherobotsConfig``, etc.) are Python
+Config dataclasses (``WherobotsConfig``, ``GlueConfig``, etc.) are Python
 objects and are not Jinja-templatable; populate their fields from Airflow
-Variables or environment variables before constructing them.
+Variables or environment variables before constructing them. ``IcebergConfig``
+is the exception: its JSON config fields are forwarded as ``op_kwargs`` strings,
+so Jinja in them (e.g. ``{{ var.value.managed_bucket_iceberg }}``) renders at
+task execution time.
 
 See ``overture_airflow_provider.config`` for the dataclasses callers should
 construct.
@@ -353,9 +356,25 @@ def _spark_agnostic_task_group(
         spark_jar_paths: str = "",
         spark_cluster_desired_worker_cores: str = "",
         spark_cluster_desired_workers: str = "",
+        iceberg_primary_config: str = "{}",
+        iceberg_wherobots_config: str = "{}",
+        iceberg_s3tables_config: str = "{}",
+        iceberg_wherobots_s3tables_config: str = "{}",
     ):
-        """Compute merged Spark config and (for Databricks) the cluster spec."""
+        """Compute merged Spark config and (for Databricks) the cluster spec.
+
+        The four ``iceberg_*_config`` JSON strings are the ``IcebergConfig``
+        fields passed as ``op_kwargs`` (not the dataclass itself), so Airflow
+        renders any Jinja in them before this task runs. They are reassembled
+        into an ``IcebergConfig`` and the platform variant is selected here.
+        """
         full = rehydrate(setup_info)
+        iceberg_config = IcebergConfig(
+            spark_config=iceberg_primary_config,
+            wherobots_spark_config=iceberg_wherobots_config,
+            s3tables_spark_config=iceberg_s3tables_config,
+            wherobots_s3tables_spark_config=iceberg_wherobots_s3tables_config,
+        )
         return get_platform_handler(full["spark_family"], full).setup_cluster(
             python_packages=python_packages,
             spark_jar_paths=spark_jar_paths,
@@ -442,6 +461,7 @@ def _spark_agnostic_task_group(
         python_packages=python_packages,
     )
     jar_result = download_jars_task(setup_info=setup_result)
+    iceberg_config = iceberg_config or IcebergConfig()
     cluster_result = setup_cluster_task(
         setup_info=setup_result,
         extra_spark_conf=extra_spark_conf,
@@ -450,6 +470,10 @@ def _spark_agnostic_task_group(
         spark_jar_paths=spark_jar_paths,
         spark_cluster_desired_worker_cores=spark_cluster_desired_worker_cores,
         spark_cluster_desired_workers=spark_cluster_desired_workers,
+        iceberg_primary_config=iceberg_config.spark_config,
+        iceberg_wherobots_config=iceberg_config.wherobots_spark_config,
+        iceberg_s3tables_config=iceberg_config.s3tables_spark_config,
+        iceberg_wherobots_s3tables_config=iceberg_config.wherobots_s3tables_spark_config,
     )
 
     execute_job_task(

--- a/tests/test_iceberg_config_templating.py
+++ b/tests/test_iceberg_config_templating.py
@@ -1,0 +1,95 @@
+"""IcebergConfig Jinja must render through the task's op_kwargs.
+
+Regression test: ``iceberg_config`` used to be closure-captured by the
+``@task_group`` factory, so Airflow never templated it and Jinja such as the
+S3 Tables warehouse ARN reached Spark verbatim. Its JSON fields are now
+forwarded as ``op_kwargs`` strings, so Jinja renders at task execution time.
+"""
+
+import datetime
+import json
+from types import SimpleNamespace
+from unittest import mock
+
+from overture_airflow_provider._airflow_compat import DAG
+from overture_airflow_provider.config import IcebergConfig
+from overture_airflow_provider.spark_agnostic_taskgroup import spark_agnostic_task_group
+
+_WAREHOUSE_TEMPLATE = (
+    "arn:aws:s3tables:us-west-2:123456789012:bucket/{{ var.value.managed_bucket_iceberg }}"
+)
+
+
+def _build_setup_cluster_op(iceberg_config):
+    with DAG(
+        dag_id="iceberg_templating_probe",
+        schedule=None,
+        start_date=datetime.datetime(2026, 1, 1),
+    ) as dag:
+        spark_agnostic_task_group(
+            group_id="grp",
+            spark_impl_name="GLUE_v5",
+            sedona_version="1.7.0",
+            iceberg_config=iceberg_config,
+        )
+    return dag, dag.get_task("grp.setup_cluster")
+
+
+def _render(dag, op, bucket):
+    # ``setup_info`` is an XComArg op_kwarg whose resolution needs a task
+    # instance; a mock satisfies it so the real render path runs and the
+    # iceberg JSON strings get Jinja-rendered.
+    context = {
+        "ti": mock.MagicMock(),
+        "task_instance": mock.MagicMock(),
+        "var": SimpleNamespace(value=SimpleNamespace(managed_bucket_iceberg=bucket)),
+    }
+    op.render_template_fields(context, jinja_env=dag.get_template_env())
+
+
+def test_s3tables_warehouse_jinja_renders_at_execution():
+    s3tables = {
+        "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.s3tables_catalog.warehouse": _WAREHOUSE_TEMPLATE,
+    }
+    dag, op = _build_setup_cluster_op(IcebergConfig(s3tables_spark_config=json.dumps(s3tables)))
+
+    # The field reaches the operator as a templatable op_kwarg, not a closure.
+    assert "{{ var.value.managed_bucket_iceberg }}" in op.op_kwargs["iceberg_s3tables_config"]
+
+    _render(dag, op, "overture-managed-iceberg")
+
+    rendered = op.op_kwargs["iceberg_s3tables_config"]
+    assert "{{" not in rendered
+    assert "bucket/overture-managed-iceberg" in rendered
+    assert json.loads(rendered)["spark.sql.catalog.s3tables_catalog.warehouse"].endswith(
+        ":bucket/overture-managed-iceberg"
+    )
+
+
+def test_all_iceberg_fields_are_op_kwargs():
+    """Every IcebergConfig variant must be plumbed as a templatable op_kwarg."""
+    dag, op = _build_setup_cluster_op(
+        IcebergConfig(
+            spark_config='{"primary": "{{ var.value.managed_bucket_iceberg }}"}',
+            wherobots_spark_config='{"w": "{{ var.value.managed_bucket_iceberg }}"}',
+            s3tables_spark_config='{"s3t": "{{ var.value.managed_bucket_iceberg }}"}',
+            wherobots_s3tables_spark_config='{"ws3t": "{{ var.value.managed_bucket_iceberg }}"}',
+        )
+    )
+
+    _render(dag, op, "B")
+
+    assert json.loads(op.op_kwargs["iceberg_primary_config"])["primary"] == "B"
+    assert json.loads(op.op_kwargs["iceberg_wherobots_config"])["w"] == "B"
+    assert json.loads(op.op_kwargs["iceberg_s3tables_config"])["s3t"] == "B"
+    assert json.loads(op.op_kwargs["iceberg_wherobots_s3tables_config"])["ws3t"] == "B"
+
+
+def test_no_iceberg_config_defaults_to_empty():
+    dag, op = _build_setup_cluster_op(None)
+
+    assert op.op_kwargs["iceberg_primary_config"] == "{}"
+    assert op.op_kwargs["iceberg_wherobots_config"] == "{}"
+    assert op.op_kwargs["iceberg_s3tables_config"] == "{}"
+    assert op.op_kwargs["iceberg_wherobots_s3tables_config"] == "{}"


### PR DESCRIPTION
## Problem

`IcebergConfig` JSON fields can carry Airflow Jinja — notably the S3 Tables warehouse ARN ending in `:bucket/{{ var.value.managed_bucket_iceberg }}`. That Jinja **never rendered** and reached Spark verbatim, yielding a malformed warehouse ARN.

## Root cause

`iceberg_config` was **closure-captured** by the `@task_group` factory and only dereferenced *inside* `setup_cluster_task` (`_select_iceberg_conf(iceberg_config, ...)`). It was never passed as `op_kwargs`. Airflow only renders Jinja in an operator's `op_kwargs` / `template_fields` — it never traverses closure variables. So unlike `extra_spark_conf` (a templated `op_kwargs` string), the iceberg config strings were frozen at parse time.

Adding `template_fields` to the dataclass does **not** help — the renderer never reaches the object (verified empirically on Airflow 2.11 and 3.2).

## Fix

Forward the four `IcebergConfig` JSON strings (`spark_config`, `wherobots_spark_config`, `s3tables_spark_config`, `wherobots_s3tables_spark_config`) through `setup_cluster_task`'s `op_kwargs` so Airflow renders their Jinja at execution time. Inside the task they are reassembled into an `IcebergConfig` and the platform variant is selected as before (selection already ran there via `setup_info[\"spark_family_name\"]`). Generic — no Overture specifics, no parse-time `Variable.get`.

## Tests

- New `tests/test_iceberg_config_templating.py`: builds the real task group in a DAG, runs `render_template_fields`, and asserts the warehouse Jinja resolves; covers all four variants and the `None` default.
- Full suite: **267 passed**; ruff clean.

## Versioning

Patch bump `0.1.3` -> `0.1.4`.

Fixes #25

Related: OvertureMaps/tf-data-platform#4003 (parent OvertureMaps/tf-data-platform#3936).