### PR TITLE
[BUG] Accept dict IcebergConfig op_kwargs under native render; consolidate JSON-config parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-06-03
+
+### Fixed
+
+- **IcebergConfig under native rendering (regression from
+  [#27](https://github.com/OvertureMaps/overture-airflow-provider/pull/27)):**
+  The four `IcebergConfig` JSON fields are forwarded as `setup_cluster_task`
+  `op_kwargs` so Airflow renders their Jinja at execution time. On DAGs with
+  `render_template_as_native_obj=True`, Airflow's native renderer `literal_eval`s
+  a rendered JSON-object string back into a `dict` before the task runs, so the
+  config arrived already parsed and the str-only parser raised
+  `TypeError: the JSON object must be str, bytes or bytearray, not dict`. The
+  config parsing now accepts an already-parsed `dict`.
+  ([#30](https://github.com/OvertureMaps/overture-airflow-provider/pull/30),
+  fixes [#29](https://github.com/OvertureMaps/overture-airflow-provider/issues/29))
+
+### Changed
+
+- Consolidated the three duplicate JSON-config parsers (`_parse_json_or_dict`,
+  and two copies of `_load_json_config` in `spark_agnostic_taskgroup` and
+  `render`) into a single `config.coerce_config_dict`. It is both validating
+  (field-named errors, must-be-a-JSON-object check) and tolerant of an
+  already-parsed `dict`. All four `IcebergConfig` variants (task group and
+  `render`) and `extra_spark_conf` now route through it; `extra_spark_conf`
+  gains the same object validation. A non-object payload — including a
+  native-rendered empty list — now raises a field-named error instead of being
+  silently dropped.
+
 ## [0.1.1] - 2026-06-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "overture-airflow-provider"
-version = "0.1.4"
+version = "0.1.5"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -46,26 +46,36 @@ def coerce_config_dict(value: Any, field_name: str = "config") -> dict:
     JSON config fields (the four ``IcebergConfig`` variants, ``extra_spark_conf``)
     are forwarded to tasks as JSON-string ``op_kwargs``. On DAGs with
     ``render_template_as_native_obj=True`` Airflow's native renderer
-    ``literal_eval``s a rendered JSON-object string back into a dict before the
-    task runs, so the value can arrive already parsed. Accept both forms; reject
-    anything that does not denote a JSON object.
+    ``literal_eval``s a rendered JSON payload into a native Python object before
+    the task runs, so the value can arrive already parsed (a dict for a JSON
+    object, but also a list/scalar for other JSON). Accept a dict or a JSON
+    object string; reject anything that does not denote a JSON object so
+    misconfiguration surfaces with a field-named error rather than being
+    silently dropped.
 
     Args:
-        value: A dict (already parsed), a JSON object string, or a falsy/``"{}"``
-            placeholder meaning "no config".
+        value: A dict (already parsed), a JSON object string, or one of the
+            "no config" placeholders ``None``, ``""``, or ``"{}"``.
         field_name: Caller-facing field name used in error messages (e.g.
             ``"IcebergConfig.spark_config"``).
     """
     if isinstance(value, dict):
         return value
-    if not value or value == "{}":
+
+    # Only these genuine placeholders mean "no config". A blanket falsy check
+    # would also swallow a native-rendered empty list/0/False as {}, masking a
+    # non-object payload that should raise.
+    if value is None or value == "" or value == "{}":
         return {}
 
-    try:
-        loaded = json.loads(value)
-    except (TypeError, ValueError) as exc:
-        detail = exc.msg if isinstance(exc, json.JSONDecodeError) else str(exc)
-        raise ValueError(f"Invalid JSON in {field_name}: {detail}") from exc
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {field_name}: {exc.msg}") from exc
+    else:
+        # Native rendering already produced a Python object (e.g. a list).
+        loaded = value
 
     if not isinstance(loaded, dict):
         raise ValueError(f"{field_name} must decode to a JSON object, got {type(loaded).__name__}")

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -35,8 +35,41 @@ Example::
     )
 """
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
+
+
+def coerce_config_dict(value: Any, field_name: str = "config") -> dict:
+    """Coerce a JSON-string-or-dict config value into a dict.
+
+    JSON config fields (the four ``IcebergConfig`` variants, ``extra_spark_conf``)
+    are forwarded to tasks as JSON-string ``op_kwargs``. On DAGs with
+    ``render_template_as_native_obj=True`` Airflow's native renderer
+    ``literal_eval``s a rendered JSON-object string back into a dict before the
+    task runs, so the value can arrive already parsed. Accept both forms; reject
+    anything that does not denote a JSON object.
+
+    Args:
+        value: A dict (already parsed), a JSON object string, or a falsy/``"{}"``
+            placeholder meaning "no config".
+        field_name: Caller-facing field name used in error messages (e.g.
+            ``"IcebergConfig.spark_config"``).
+    """
+    if isinstance(value, dict):
+        return value
+    if not value or value == "{}":
+        return {}
+
+    try:
+        loaded = json.loads(value)
+    except (TypeError, ValueError) as exc:
+        detail = exc.msg if isinstance(exc, json.JSONDecodeError) else str(exc)
+        raise ValueError(f"Invalid JSON in {field_name}: {detail}") from exc
+
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{field_name} must decode to a JSON object, got {type(loaded).__name__}")
+    return loaded
 
 
 @dataclass

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -41,6 +41,7 @@ from overture_airflow_provider.config import (
     IcebergConfig,
     PackageRegistryConfig,
     WherobotsConfig,
+    coerce_config_dict,
 )
 from overture_airflow_provider.runner_assets import _RUNNER_FILES, _file_sha256, get_runner_path
 from overture_airflow_provider.spark import SparkFamily, SparkImpl, SparkSedona
@@ -126,24 +127,6 @@ def _jsonify(obj: Any) -> Any:
     return obj
 
 
-def _load_json_config(raw: str | None, field_name: str) -> dict[str, Any]:
-    """Parse a JSON config string and require a JSON object payload."""
-    if not raw or raw == "{}":
-        return {}
-
-    try:
-        loaded = json.loads(raw)
-    except (TypeError, ValueError) as exc:
-        detail = exc.msg if isinstance(exc, json.JSONDecodeError) else str(exc)
-        raise ValueError(f"Invalid JSON in IcebergConfig.{field_name}: {detail}") from exc
-
-    if not isinstance(loaded, dict):
-        raise ValueError(
-            f"IcebergConfig.{field_name} must decode to a JSON object, got {type(loaded).__name__}"
-        )
-    return loaded
-
-
 def _select_iceberg_spark_config(
     iceberg_config: IcebergConfig | None, family: SparkFamily
 ) -> dict[str, Any]:
@@ -152,16 +135,19 @@ def _select_iceberg_spark_config(
         return {}
 
     if family == SparkFamily.WHEROBOTS:
-        primary = _load_json_config(iceberg_config.wherobots_spark_config, "wherobots_spark_config")
-        s3tables = _load_json_config(
+        primary = coerce_config_dict(
+            iceberg_config.wherobots_spark_config,
+            "IcebergConfig.wherobots_spark_config",
+        )
+        s3tables = coerce_config_dict(
             iceberg_config.wherobots_s3tables_spark_config,
-            "wherobots_s3tables_spark_config",
+            "IcebergConfig.wherobots_s3tables_spark_config",
         )
     else:
-        primary = _load_json_config(iceberg_config.spark_config, "spark_config")
-        s3tables = _load_json_config(
+        primary = coerce_config_dict(iceberg_config.spark_config, "IcebergConfig.spark_config")
+        s3tables = coerce_config_dict(
             iceberg_config.s3tables_spark_config,
-            "s3tables_spark_config",
+            "IcebergConfig.s3tables_spark_config",
         )
 
     return {**primary, **s3tables}

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -48,7 +48,6 @@ construct.
 
 import datetime
 import json
-from typing import Any
 
 from overture_airflow_provider._airflow_compat import task, task_group
 from overture_airflow_provider._setup import setup_spark_job
@@ -59,6 +58,7 @@ from overture_airflow_provider.config import (
     IcebergConfig,
     PackageRegistryConfig,
     WherobotsConfig,
+    coerce_config_dict,
 )
 from overture_airflow_provider.setup_info import rehydrate, to_xcom
 from overture_airflow_provider.spark_platform_handlers import get_platform_handler
@@ -204,41 +204,6 @@ def spark_agnostic_mapped_task_group(
 # =============================================================================
 
 
-def _parse_json_or_dict(value: Any) -> dict:
-    """Accept either a parsed dict or a JSON string and return a dict."""
-    if isinstance(value, dict):
-        return value
-    if value and value != "{}":
-        return json.loads(value)
-    return {}
-
-
-def _load_json_config(raw: str | dict | None, field_name: str = "config") -> dict:
-    """Parse a JSON config string, returning an empty dict for falsy/empty values.
-
-    A dict is accepted as-is. The four ``IcebergConfig`` JSON strings are
-    forwarded as ``op_kwargs``; on DAGs with ``render_template_as_native_obj=True``
-    Airflow's native renderer ``literal_eval``s a rendered JSON-object string back
-    into a dict before the task runs, so ``raw`` arrives already parsed. This
-    mirrors ``_parse_json_or_dict`` used for ``extra_spark_conf``.
-    """
-    if isinstance(raw, dict):
-        return raw
-    if not raw or raw == "{}":
-        return {}
-
-    try:
-        loaded = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Invalid JSON in IcebergConfig.{field_name}: {exc.msg}") from exc
-
-    if not isinstance(loaded, dict):
-        raise ValueError(
-            f"IcebergConfig.{field_name} must decode to a JSON object, got {type(loaded).__name__}"
-        )
-    return loaded
-
-
 def _select_iceberg_conf(iceberg_config: IcebergConfig | None, spark_family_name: str) -> dict:
     """Pick the right Iceberg config variants for the resolved platform family.
 
@@ -250,17 +215,21 @@ def _select_iceberg_conf(iceberg_config: IcebergConfig | None, spark_family_name
         return {}
 
     if spark_family_name == "WHEROBOTS":
-        primary = _load_json_config(
-            iceberg_config.wherobots_spark_config, field_name="wherobots_spark_config"
+        primary = coerce_config_dict(
+            iceberg_config.wherobots_spark_config,
+            field_name="IcebergConfig.wherobots_spark_config",
         )
-        s3tables = _load_json_config(
+        s3tables = coerce_config_dict(
             iceberg_config.wherobots_s3tables_spark_config,
-            field_name="wherobots_s3tables_spark_config",
+            field_name="IcebergConfig.wherobots_s3tables_spark_config",
         )
     else:
-        primary = _load_json_config(iceberg_config.spark_config, field_name="spark_config")
-        s3tables = _load_json_config(
-            iceberg_config.s3tables_spark_config, field_name="s3tables_spark_config"
+        primary = coerce_config_dict(
+            iceberg_config.spark_config, field_name="IcebergConfig.spark_config"
+        )
+        s3tables = coerce_config_dict(
+            iceberg_config.s3tables_spark_config,
+            field_name="IcebergConfig.s3tables_spark_config",
         )
 
     if s3tables:
@@ -387,7 +356,7 @@ def _spark_agnostic_task_group(
         return get_platform_handler(full["spark_family"], full).setup_cluster(
             python_packages=python_packages,
             spark_jar_paths=spark_jar_paths,
-            extra_spark_conf=_parse_json_or_dict(extra_spark_conf),
+            extra_spark_conf=coerce_config_dict(extra_spark_conf, field_name="extra_spark_conf"),
             extra_spark_env_vars=extra_spark_env_vars,
             spark_cluster_desired_worker_cores=spark_cluster_desired_worker_cores,
             spark_cluster_desired_workers=spark_cluster_desired_workers,

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -213,8 +213,17 @@ def _parse_json_or_dict(value: Any) -> dict:
     return {}
 
 
-def _load_json_config(raw: str | None, field_name: str = "config") -> dict:
-    """Parse a JSON config string, returning an empty dict for falsy/empty values."""
+def _load_json_config(raw: str | dict | None, field_name: str = "config") -> dict:
+    """Parse a JSON config string, returning an empty dict for falsy/empty values.
+
+    A dict is accepted as-is. The four ``IcebergConfig`` JSON strings are
+    forwarded as ``op_kwargs``; on DAGs with ``render_template_as_native_obj=True``
+    Airflow's native renderer ``literal_eval``s a rendered JSON-object string back
+    into a dict before the task runs, so ``raw`` arrives already parsed. This
+    mirrors ``_parse_json_or_dict`` used for ``extra_spark_conf``.
+    """
+    if isinstance(raw, dict):
+        return raw
     if not raw or raw == "{}":
         return {}
 

--- a/tests/test_coerce_config_dict.py
+++ b/tests/test_coerce_config_dict.py
@@ -1,0 +1,39 @@
+"""Tests for the shared coerce_config_dict helper.
+
+It is the single parser for every JSON-string-or-dict config op_kwarg (the four
+IcebergConfig variants and extra_spark_conf), so it must accept both a JSON
+object string and an already-parsed dict (the render_template_as_native_obj=True
+case) while rejecting non-object payloads with a field-named error.
+"""
+
+import pytest
+
+from overture_airflow_provider.config import coerce_config_dict
+
+
+def test_parses_json_object_string():
+    assert coerce_config_dict('{"a": "b", "n": 3000}') == {"a": "b", "n": 3000}
+
+
+def test_accepts_dict_as_is():
+    value = {"a": "b", "n": 3000}
+    assert coerce_config_dict(value) is value
+
+
+def test_empty_and_falsy_become_empty_dict():
+    assert coerce_config_dict("{}") == {}
+    assert coerce_config_dict("") == {}
+    assert coerce_config_dict(None) == {}
+
+
+def test_invalid_json_uses_field_name():
+    with pytest.raises(ValueError, match=r"Invalid JSON in extra_spark_conf"):
+        coerce_config_dict('{"bad"', field_name="extra_spark_conf")
+
+
+def test_non_object_json_uses_field_name():
+    with pytest.raises(
+        ValueError,
+        match=r"IcebergConfig\.spark_config must decode to a JSON object, got list",
+    ):
+        coerce_config_dict("[]", field_name="IcebergConfig.spark_config")

--- a/tests/test_coerce_config_dict.py
+++ b/tests/test_coerce_config_dict.py
@@ -37,3 +37,23 @@ def test_non_object_json_uses_field_name():
         match=r"IcebergConfig\.spark_config must decode to a JSON object, got list",
     ):
         coerce_config_dict("[]", field_name="IcebergConfig.spark_config")
+
+
+def test_native_rendered_empty_list_is_rejected_not_swallowed():
+    """A native-rendered empty JSON array is falsy but is NOT a "no config"
+    placeholder; it must raise rather than be silently treated as {}."""
+    with pytest.raises(
+        ValueError,
+        match=r"IcebergConfig\.spark_config must decode to a JSON object, got list",
+    ):
+        coerce_config_dict([], field_name="IcebergConfig.spark_config")
+
+
+def test_native_rendered_nonempty_list_is_rejected():
+    with pytest.raises(ValueError, match=r"must decode to a JSON object, got list"):
+        coerce_config_dict([{"a": 1}], field_name="IcebergConfig.spark_config")
+
+
+def test_native_rendered_scalar_is_rejected():
+    with pytest.raises(ValueError, match=r"must decode to a JSON object, got int"):
+        coerce_config_dict(0, field_name="extra_spark_conf")

--- a/tests/test_iceberg_config_templating.py
+++ b/tests/test_iceberg_config_templating.py
@@ -23,12 +23,11 @@ _WAREHOUSE_TEMPLATE = (
 )
 
 
-def _build_setup_cluster_op(iceberg_config, render_native=False):
+def _build_setup_cluster_op(iceberg_config):
     with DAG(
         dag_id="iceberg_templating_probe",
         schedule=None,
         start_date=datetime.datetime(2026, 1, 1),
-        render_template_as_native_obj=render_native,
     ) as dag:
         spark_agnostic_task_group(
             group_id="grp",
@@ -110,9 +109,22 @@ def test_native_render_turns_op_kwarg_into_dict():
         "spark.sql.catalog.s3tables_catalog.warehouse": _WAREHOUSE_TEMPLATE,
         "spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections": 3000,
     }
-    dag, op = _build_setup_cluster_op(
-        IcebergConfig(spark_config=json.dumps(s3tables)), render_native=True
-    )
+    # render_template_as_native_obj=True is the consumer-side DAG setting that
+    # triggers the bug; build it here so dag.get_template_env() is a
+    # NativeEnvironment and the rendered op_kwarg comes back as a dict.
+    with DAG(
+        dag_id="iceberg_native_probe",
+        schedule=None,
+        start_date=datetime.datetime(2026, 1, 1),
+        render_template_as_native_obj=True,
+    ) as dag:
+        spark_agnostic_task_group(
+            group_id="grp",
+            spark_impl_name="GLUE_v5",
+            sedona_version="1.7.0",
+            iceberg_config=IcebergConfig(spark_config=json.dumps(s3tables)),
+        )
+    op = dag.get_task("grp.setup_cluster")
 
     _render(dag, op, "overture-managed-iceberg")
 

--- a/tests/test_iceberg_config_templating.py
+++ b/tests/test_iceberg_config_templating.py
@@ -13,18 +13,22 @@ from unittest import mock
 
 from overture_airflow_provider._airflow_compat import DAG
 from overture_airflow_provider.config import IcebergConfig
-from overture_airflow_provider.spark_agnostic_taskgroup import spark_agnostic_task_group
+from overture_airflow_provider.spark_agnostic_taskgroup import (
+    _select_iceberg_conf,
+    spark_agnostic_task_group,
+)
 
 _WAREHOUSE_TEMPLATE = (
     "arn:aws:s3tables:us-west-2:123456789012:bucket/{{ var.value.managed_bucket_iceberg }}"
 )
 
 
-def _build_setup_cluster_op(iceberg_config):
+def _build_setup_cluster_op(iceberg_config, render_native=False):
     with DAG(
         dag_id="iceberg_templating_probe",
         schedule=None,
         start_date=datetime.datetime(2026, 1, 1),
+        render_template_as_native_obj=render_native,
     ) as dag:
         spark_agnostic_task_group(
             group_id="grp",
@@ -93,3 +97,33 @@ def test_no_iceberg_config_defaults_to_empty():
     assert op.op_kwargs["iceberg_wherobots_config"] == "{}"
     assert op.op_kwargs["iceberg_s3tables_config"] == "{}"
     assert op.op_kwargs["iceberg_wherobots_s3tables_config"] == "{}"
+
+
+def test_native_render_turns_op_kwarg_into_dict():
+    """On render_template_as_native_obj=True DAGs, Airflow's NativeEnvironment
+    literal_evals a rendered JSON-object op_kwarg into a dict. setup_cluster_task
+    reassembles IcebergConfig from these values, so _select_iceberg_conf must
+    tolerate dicts. Regression for: json.loads(dict) -> TypeError.
+    """
+    s3tables = {
+        "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.s3tables_catalog.warehouse": _WAREHOUSE_TEMPLATE,
+        "spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections": 3000,
+    }
+    dag, op = _build_setup_cluster_op(
+        IcebergConfig(spark_config=json.dumps(s3tables)), render_native=True
+    )
+
+    _render(dag, op, "overture-managed-iceberg")
+
+    # NativeEnvironment converted the JSON-object string into a real dict.
+    rendered = op.op_kwargs["iceberg_primary_config"]
+    assert isinstance(rendered, dict)
+
+    # The reassembled IcebergConfig must resolve without raising.
+    cfg = IcebergConfig(spark_config=rendered)
+    result = _select_iceberg_conf(cfg, "GLUE")
+    assert result["spark.sql.catalog.s3tables_catalog.warehouse"].endswith(
+        ":bucket/overture-managed-iceberg"
+    )
+    assert result["spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections"] == 3000

--- a/tests/test_select_iceberg_conf.py
+++ b/tests/test_select_iceberg_conf.py
@@ -77,6 +77,44 @@ class TestSelectIcebergConfPrimaryOnly:
             _select_iceberg_conf(cfg, "WHEROBOTS")
 
 
+class TestSelectIcebergConfDictInput:
+    """On DAGs with render_template_as_native_obj=True, Airflow's native renderer
+    literal_evals a rendered JSON-object op_kwarg back into a dict, so the
+    IcebergConfig fields arrive already parsed. _select_iceberg_conf must accept
+    dicts as well as JSON strings (regression for the json.loads(dict) TypeError).
+    """
+
+    def test_glue_accepts_dict_spark_config(self):
+        cfg = IcebergConfig(spark_config=_rest_catalog_config())
+        assert _select_iceberg_conf(cfg, "GLUE") == _rest_catalog_config()
+
+    def test_wherobots_accepts_dict_spark_config(self):
+        cfg = IcebergConfig(wherobots_spark_config=_wherobots_catalog_config())
+        assert _select_iceberg_conf(cfg, "WHEROBOTS") == _wherobots_catalog_config()
+
+    def test_glue_merges_dict_primary_and_dict_s3tables(self):
+        cfg = IcebergConfig(
+            spark_config=_rest_catalog_config(),
+            s3tables_spark_config=_s3tables_catalog_config(),
+        )
+        result = _select_iceberg_conf(cfg, "GLUE")
+        assert "spark.sql.catalog.iceberg_catalog" in result
+        assert "spark.sql.catalog.s3tables_catalog" in result
+
+    def test_dict_with_int_value_preserved(self):
+        """Spark config values may be ints (e.g. max-connections); native render
+        keeps them as ints in the dict, which must survive untouched."""
+        cfg = IcebergConfig(
+            spark_config={
+                "spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections": 3000
+            }
+        )
+        result = _select_iceberg_conf(cfg, "GLUE")
+        assert (
+            result["spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections"] == 3000
+        )
+
+
 class TestSelectIcebergConfS3Tables:
     def test_glue_merges_primary_and_s3tables(self):
         cfg = IcebergConfig(


### PR DESCRIPTION
## What

Fixes #29 — `TypeError: the JSON object must be str, bytes or bytearray, not dict` thrown from `setup_cluster_task` → `_select_iceberg_conf` → `_load_json_config`.

## Root cause

#27 forwarded the four `IcebergConfig` JSON strings as `setup_cluster_task` op_kwargs so Airflow renders their Jinja at execution time. On DAGs with `render_template_as_native_obj=True`, Airflow's `NativeEnvironment` `literal_eval`s a rendered JSON-object string back into a **dict** before the task body runs, so the `IcebergConfig` fields arrive already parsed.

`_select_iceberg_conf` routed those values through `_load_json_config`, which only handled `str`/`None` and did `json.loads(dict)` → `TypeError`.

The sibling `_parse_json_or_dict` (used for `extra_spark_conf`) already tolerates dicts for exactly this native-render reason — the iceberg path was the gap. The existing #27 test only used a non-native DAG, so this path was uncovered.

## Change

- `_load_json_config`: return the value as-is when it is already a `dict`. Covers all four iceberg fields; no-op for the normal string path; preserves int values (e.g. `max-connections: 3000`).
- Tests:
  - `test_select_iceberg_conf.py::TestSelectIcebergConfDictInput` — direct dict input (incl. int value).
  - `test_iceberg_config_templating.py::test_native_render_turns_op_kwarg_into_dict` — `render_template_as_native_obj=True` DAG proving Airflow converts the op_kwarg to a dict and the reassembled config resolves.
- Patch bump `0.1.4 → 0.1.5`.

## Test

`pytest -q` → 272 passed.

## Follow-up (separate)

Pin the provider in `tf-data-platform`'s `airflow/requirements.txt` to a tag/SHA instead of `@main` so unrelated deploys don't silently pull provider changes.
