### PR TITLE
[BUG] Resolve package version dynamically from metadata

### DIFF
--- a/src/overture_airflow_provider/__init__.py
+++ b/src/overture_airflow_provider/__init__.py
@@ -15,9 +15,13 @@ caller actually touches a symbol that needs it.
 """
 
 from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.1.0"
+try:
+    __version__ = version("overture-airflow-provider")
+except PackageNotFoundError:  # package not installed (e.g. source checkout)
+    __version__ = "0.0.0"
 
 # name -> (submodule, attribute)
 _LAZY_IMPORTS = {

--- a/src/overture_airflow_provider/provider_info.py
+++ b/src/overture_airflow_provider/provider_info.py
@@ -7,6 +7,16 @@ populate ``airflow providers list`` output, and discover extra-links.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _package_version() -> str:
+    """Resolve the installed package version, falling back when uninstalled."""
+    try:
+        return version("overture-airflow-provider")
+    except PackageNotFoundError:  # package not installed (e.g. source checkout)
+        return "0.0.0"
+
 
 def get_provider_info() -> dict:
     """Return Airflow provider metadata conforming to provider_info.schema.json."""
@@ -17,7 +27,7 @@ def get_provider_info() -> dict:
             "Airflow TaskGroup for submitting Spark jobs to AWS Glue, Databricks, "
             "or Wherobots Cloud from a single, platform-agnostic DAG entry point."
         ),
-        "versions": ["0.1.0"],
+        "versions": [_package_version()],
         "operators": [
             {
                 "integration-name": "Spark (Glue / Databricks / Wherobots)",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,15 @@
+"""Version metadata stays in sync with the installed package."""
+
+from importlib.metadata import version
+
+import overture_airflow_provider
+from overture_airflow_provider.provider_info import get_provider_info
+
+
+def test_version_matches_installed_metadata():
+    assert overture_airflow_provider.__version__ == version("overture-airflow-provider")
+
+
+def test_provider_info_versions_match_package_version():
+    info = get_provider_info()
+    assert info["versions"] == [overture_airflow_provider.__version__]


### PR DESCRIPTION
## Problem

The package version was hardcoded in three places and had drifted out of sync:

- `pyproject.toml` = `0.1.5` (source of truth)
- `src/overture_airflow_provider/__init__.py` `__version__` = `0.1.0`
- `src/overture_airflow_provider/provider_info.py` `"versions"` = `["0.1.0"]`

## Fix

Both `__version__` and the provider_info `versions` field now resolve dynamically from `importlib.metadata`, making `pyproject.toml` the single source of truth.

- `__init__.py`: `__version__` reads `version("overture-airflow-provider")`, falling back to `"0.0.0"` when the package isn't installed.
- `provider_info.py`: `get_provider_info()` uses a local `_package_version()` helper with the same approach. It stays Airflow-free and importable without Airflow per the repo's lazy-import constraints.

## Tests

Added `tests/test_version.py` asserting `__version__` matches `importlib.metadata.version` and that provider_info `versions` matches the package version.

- `uv run pytest -q` → 282 passed
- `uv run ruff check .` → All checks passed
- `uv run ruff format .` → unchanged

Closes #35