### PR TITLE
[SECURITY] Keep CodeArtifact auth token out of pip argv and logs

### DIFF
--- a/src/overture_airflow_provider/python_package_utils.py
+++ b/src/overture_airflow_provider/python_package_utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from collections.abc import Callable
 from datetime import UTC, datetime
 from enum import Enum
@@ -12,6 +13,20 @@ import boto3
 import requests
 from boto3.s3.transfer import S3Transfer
 from packaging.version import InvalidVersion, Version
+
+# Matches the ``password`` portion of a ``scheme://user:password@host`` URL so
+# it can be redacted before any URL (e.g. a CodeArtifact index URL embedding an
+# auth token) is logged or surfaced in an exception message.
+_URL_CREDENTIALS_RE = re.compile(r"(://[^/\s:@]+:)([^/\s@]+)(@)")
+
+
+def mask_url_credentials(text: str) -> str:
+    """Replace the password segment of any ``user:password@`` URL in ``text`` with ``***``.
+
+    Works on both bare URLs and free-form text (e.g. subprocess stderr) that may
+    contain one or more credential-bearing URLs.
+    """
+    return _URL_CREDENTIALS_RE.sub(r"\1***\3", text)
 
 
 class PackageVersionStrategy(Enum):
@@ -195,23 +210,28 @@ class PyPiDownloader:
             # We don't care if the package is incompatible with the local Airflow
             # python version; we only want to download it.
             "--ignore-requires-python",
-            "--index-url",
-            self.client.get_url(),
             "--dest",
             self.output_dir,
             *packages,
         ]
 
+        # The index URL embeds the CodeArtifact auth token. Pass it via the
+        # environment (PIP_INDEX_URL) instead of an ``--index-url`` argument so
+        # the token never appears in the process arguments, and therefore cannot
+        # leak through any subprocess error message that echoes the command line.
+        pip_env = {**os.environ, "PIP_INDEX_URL": self.client.get_url()}
+
         try:
             import sh
 
-            sh.pip(*pip_command)
+            sh.pip(*pip_command, _env=pip_env)
             logging.info("Successfully downloaded %s and dependencies.", packages)
         except sh.ErrorReturnCode as exc:
+            # Mask credentials in case pip echoed the index URL into stderr.
             logging.error(
                 "Error downloading pypi packages %s: %s",
                 packages,
-                exc.stderr.decode(),
+                mask_url_credentials(exc.stderr.decode()),
             )
             raise
 

--- a/tests/test_python_package_utils.py
+++ b/tests/test_python_package_utils.py
@@ -1,0 +1,105 @@
+"""Tests for python_package_utils, focused on keeping the CodeArtifact auth
+token out of process arguments and log/exception output (issue #36)."""
+
+import logging
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from overture_airflow_provider.python_package_utils import (
+    PyPiDownloader,
+    mask_url_credentials,
+)
+
+_TOKEN = "SUPERSECRETAUTHTOKEN"
+_INDEX_URL = (
+    f"https://aws:{_TOKEN}@domain-123.d.codeartifact.us-east-1.amazonaws.com/pypi/repo/simple/"
+)
+
+
+def _make_fake_sh(pip_impl):
+    """Build a fake ``sh`` module exposing ``pip`` and ``ErrorReturnCode``."""
+    fake_sh = types.ModuleType("sh")
+
+    class ErrorReturnCode(Exception):
+        def __init__(self, stderr: bytes = b""):
+            super().__init__("pip failed")
+            self.stderr = stderr
+
+    fake_sh.pip = pip_impl
+    fake_sh.ErrorReturnCode = ErrorReturnCode
+    return fake_sh
+
+
+def _make_downloader(tmp_path):
+    client = MagicMock()
+    client.get_url.return_value = _INDEX_URL
+    return PyPiDownloader(client, str(tmp_path))
+
+
+def test_mask_url_credentials_redacts_password():
+    assert mask_url_credentials(_INDEX_URL) == (
+        "https://aws:***@domain-123.d.codeartifact.us-east-1.amazonaws.com/pypi/repo/simple/"
+    )
+    assert _TOKEN not in mask_url_credentials(_INDEX_URL)
+
+
+def test_mask_url_credentials_handles_free_text():
+    text = f"could not connect to {_INDEX_URL} (timeout)"
+    masked = mask_url_credentials(text)
+    assert _TOKEN not in masked
+    assert "***@" in masked
+
+
+def test_mask_url_credentials_noop_without_credentials():
+    url = "https://pypi.org/simple/"
+    assert mask_url_credentials(url) == url
+
+
+def test_token_passed_via_env_not_argv(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_pip(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs.get("_env")
+
+    monkeypatch.setitem(sys.modules, "sh", _make_fake_sh(fake_pip))
+
+    _make_downloader(tmp_path).download_packages(["mypkg"], "3.11")
+
+    # Token must never appear in the command-line arguments.
+    assert all(_TOKEN not in str(arg) for arg in captured["args"])
+    assert "--index-url" not in captured["args"]
+    # Token is delivered to pip via the environment instead.
+    assert captured["env"]["PIP_INDEX_URL"] == _INDEX_URL
+
+
+def test_error_message_masks_token(tmp_path, monkeypatch, caplog):
+    fake_sh = _make_fake_sh(None)
+
+    def fake_pip(*args, **kwargs):
+        raise fake_sh.ErrorReturnCode(stderr=f"ERROR: failed fetching {_INDEX_URL}".encode())
+
+    fake_sh.pip = fake_pip
+    monkeypatch.setitem(sys.modules, "sh", fake_sh)
+
+    downloader = _make_downloader(tmp_path)
+    with caplog.at_level(logging.ERROR), pytest.raises(fake_sh.ErrorReturnCode):
+        downloader.download_packages(["mypkg"], "3.11")
+
+    assert _TOKEN not in caplog.text
+    assert "***@" in caplog.text
+
+
+def test_download_packages_noop_when_empty(tmp_path, monkeypatch):
+    called = {"pip": False}
+
+    def fake_pip(*args, **kwargs):
+        called["pip"] = True
+
+    monkeypatch.setitem(sys.modules, "sh", _make_fake_sh(fake_pip))
+
+    _make_downloader(tmp_path).download_packages([], "3.11")
+    assert called["pip"] is False


### PR DESCRIPTION
## Summary

`python_package_utils.py` built the CodeArtifact index URL with the short-lived auth token embedded (`https://aws:<token>@…`) and passed it to pip as an `--index-url` argument. If a pip subprocess failed and an error echoed the command line, the token could leak into Airflow task logs.

## Fix

- Pass the index URL via the `PIP_INDEX_URL` environment variable instead of `--index-url`, so the token never appears in the process arguments (preferred option 2 from the issue).
- Add a `mask_url_credentials` helper that redacts the `user:password@` segment of any URL, and use it when logging pip stderr as defense-in-depth (in case pip echoes the index URL).

## Tests

New `tests/test_python_package_utils.py`:
- Token is delivered via `PIP_INDEX_URL` and is **not** present in the pip argv (no `--index-url`).
- Logged error message masks the token (`***@`) and never contains the raw token.
- Masking helper unit tests (URL, free-form text, no-op without credentials).
- Empty-package no-op.

`uv run pytest -v` (286 passed), `uv run ruff check .`, and `uv run ruff format .` all pass.

Closes #36

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>