### PR TITLE
[ENHANCEMENT](config) Fail-fast validation for required config fields

### DIFF
--- a/src/overture_airflow_provider/_setup.py
+++ b/src/overture_airflow_provider/_setup.py
@@ -40,10 +40,8 @@ def setup_spark_job(
     (``spark_impl``, ``spark_family``, ``py_pi_client``) which are stripped
     before XCom push and rehydrated downstream.
     """
-    package_registry = package_registry or PackageRegistryConfig(
-        domain_owner="", domain="", repository=""
-    )
-    artifact_store = artifact_store or ArtifactStoreConfig(s3_bucket="")
+    package_registry = package_registry or PackageRegistryConfig.unset()
+    artifact_store = artifact_store or ArtifactStoreConfig.unset()
     glue_config = glue_config or GlueConfig()
     databricks_config = databricks_config or DatabricksConfig()
     wherobots_config = wherobots_config or WherobotsConfig()

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -36,8 +36,19 @@ Example::
 """
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from typing import Any
+
+
+def _require_non_empty(cls_name: str, **fields: str) -> None:
+    """Raise ``ValueError`` for any required string field that is empty/blank.
+
+    Whitespace-only values are treated as empty so callers get a clear
+    construction-time error instead of a cryptic downstream AWS failure.
+    """
+    for name, value in fields.items():
+        if not value or not value.strip():
+            raise ValueError(f"{cls_name}.{name} must not be empty")
 
 
 def coerce_config_dict(value: Any, field_name: str = "config") -> dict:
@@ -101,6 +112,10 @@ class PackageRegistryConfig:
             (e.g. ``"maven/my-maven"``). Combined with the registry host to
             form the base Maven URL. Defaults to ``"maven/" + maven_repository``
             when empty.
+
+    Raises:
+        ValueError: If any required field (``domain_owner``, ``domain``,
+            ``repository``, ``region``) is empty or whitespace-only.
     """
 
     domain_owner: str
@@ -109,6 +124,27 @@ class PackageRegistryConfig:
     region: str = "us-east-1"
     maven_repository: str = ""
     maven_repository_path: str = ""
+    _validate: InitVar[bool] = True
+
+    def __post_init__(self, _validate: bool) -> None:
+        if not _validate:
+            return
+        _require_non_empty(
+            "PackageRegistryConfig",
+            domain_owner=self.domain_owner,
+            domain=self.domain,
+            repository=self.repository,
+            region=self.region,
+        )
+
+    @classmethod
+    def unset(cls) -> "PackageRegistryConfig":
+        """Build a disabled placeholder (registry not configured), skipping validation.
+
+        Used internally when a caller omits ``package_registry`` entirely; the
+        feature is treated as disabled rather than misconfigured.
+        """
+        return cls(domain_owner="", domain="", repository="", _validate=False)
 
 
 @dataclass
@@ -127,6 +163,9 @@ class ArtifactStoreConfig:
         force_pip_packages: Package-name substrings that must be installed via
             pip on the cluster instead of being uploaded as wheels (e.g.
             native packages needing platform-specific resolution at runtime).
+
+    Raises:
+        ValueError: If ``s3_bucket`` is empty or whitespace-only.
     """
 
     s3_bucket: str
@@ -153,6 +192,22 @@ class ArtifactStoreConfig:
             },
         )
     """
+
+    _validate: InitVar[bool] = True
+
+    def __post_init__(self, _validate: bool) -> None:
+        if not _validate:
+            return
+        _require_non_empty("ArtifactStoreConfig", s3_bucket=self.s3_bucket)
+
+    @classmethod
+    def unset(cls) -> "ArtifactStoreConfig":
+        """Build a disabled placeholder (asset store not configured), skipping validation.
+
+        Used internally when a caller omits ``artifact_store`` entirely; the
+        feature is treated as disabled rather than misconfigured.
+        """
+        return cls(s3_bucket="", _validate=False)
 
 
 @dataclass

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -405,10 +405,8 @@ def render_spark_job(
     run; otherwise placeholder URIs (``s3://.../REPLACE-ME.whl``) are emitted
     so the operator kwargs structure is still complete.
     """
-    package_registry = package_registry or PackageRegistryConfig(
-        domain_owner="", domain="", repository=""
-    )
-    artifact_store = artifact_store or ArtifactStoreConfig(s3_bucket="")
+    package_registry = package_registry or PackageRegistryConfig.unset()
+    artifact_store = artifact_store or ArtifactStoreConfig.unset()
     glue_config = glue_config or GlueConfig()
     databricks_config = databricks_config or DatabricksConfig()
     wherobots_config = wherobots_config or WherobotsConfig()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,99 @@
+"""Tests for fail-fast validation of required config dataclass fields.
+
+Required fields must reject empty/whitespace-only values at construction time
+with a clear, field-named ``ValueError`` rather than failing later with a
+cryptic S3/CodeArtifact error. Optional fields and the internal ``unset()``
+disabled placeholders must still construct fine.
+"""
+
+import dataclasses
+
+import pytest
+
+from overture_airflow_provider.config import (
+    ArtifactStoreConfig,
+    PackageRegistryConfig,
+)
+
+
+class TestPackageRegistryConfig:
+    def test_valid_constructs(self):
+        cfg = PackageRegistryConfig(
+            domain_owner="123456789012",
+            domain="my-pypi",
+            repository="my-repo",
+            region="us-east-1",
+        )
+        assert cfg.domain == "my-pypi"
+
+    def test_defaults_region_and_optional_maven(self):
+        cfg = PackageRegistryConfig(
+            domain_owner="123456789012", domain="my-pypi", repository="my-repo"
+        )
+        assert cfg.region == "us-east-1"
+        assert cfg.maven_repository == ""
+        assert cfg.maven_repository_path == ""
+
+    @pytest.mark.parametrize("field_name", ["domain_owner", "domain", "repository", "region"])
+    def test_empty_required_field_raises(self, field_name):
+        kwargs = {
+            "domain_owner": "123456789012",
+            "domain": "my-pypi",
+            "repository": "my-repo",
+            "region": "us-east-1",
+            field_name: "",
+        }
+        with pytest.raises(
+            ValueError, match=f"PackageRegistryConfig.{field_name} must not be empty"
+        ):
+            PackageRegistryConfig(**kwargs)
+
+    def test_whitespace_only_is_rejected(self):
+        with pytest.raises(ValueError, match="PackageRegistryConfig.domain must not be empty"):
+            PackageRegistryConfig(domain_owner="o", domain="   ", repository="r")
+
+    def test_issue_example_fails_fast(self):
+        with pytest.raises(
+            ValueError, match="PackageRegistryConfig.domain_owner must not be empty"
+        ):
+            PackageRegistryConfig(
+                domain="", domain_owner="", repository="my-repo", region="us-east-1"
+            )
+
+    def test_unset_placeholder_skips_validation(self):
+        cfg = PackageRegistryConfig.unset()
+        assert cfg.domain_owner == ""
+        assert cfg.domain == ""
+        assert cfg.repository == ""
+
+    def test_validate_initvar_not_a_stored_field(self):
+        names = {f.name for f in dataclasses.fields(PackageRegistryConfig)}
+        assert "_validate" not in names
+
+
+class TestArtifactStoreConfig:
+    def test_valid_constructs(self):
+        cfg = ArtifactStoreConfig(s3_bucket="my-bucket")
+        assert cfg.s3_bucket == "my-bucket"
+        assert cfg.s3_root == "spark-agnostic-operator"
+
+    def test_empty_s3_bucket_raises(self):
+        with pytest.raises(ValueError, match="ArtifactStoreConfig.s3_bucket must not be empty"):
+            ArtifactStoreConfig(s3_bucket="")
+
+    def test_issue_example_fails_fast(self):
+        with pytest.raises(ValueError, match="ArtifactStoreConfig.s3_bucket must not be empty"):
+            ArtifactStoreConfig(s3_bucket="", s3_root="prefix")
+
+    def test_whitespace_only_is_rejected(self):
+        with pytest.raises(ValueError, match="ArtifactStoreConfig.s3_bucket must not be empty"):
+            ArtifactStoreConfig(s3_bucket="   ")
+
+    def test_unset_placeholder_skips_validation(self):
+        cfg = ArtifactStoreConfig.unset()
+        assert cfg.s3_bucket == ""
+        assert cfg.s3_root == "spark-agnostic-operator"
+
+    def test_validate_initvar_not_a_stored_field(self):
+        names = {f.name for f in dataclasses.fields(ArtifactStoreConfig)}
+        assert "_validate" not in names


### PR DESCRIPTION
## Summary

Required config fields were accepted as empty strings and only blew up later with cryptic S3/CodeArtifact errors. This adds construction-time validation so misconfiguration surfaces immediately with a clear, field-named message.

## Changes

- `PackageRegistryConfig` and `ArtifactStoreConfig` now validate required fields in `__post_init__`, raising `ValueError("<Class>.<field> must not be empty")` for empty or whitespace-only values.
  - Required: `domain_owner`, `domain`, `repository`, `region` (PackageRegistryConfig); `s3_bucket` (ArtifactStoreConfig).
  - Optional fields (`maven_repository`, `maven_repository_path`, `s3_root`, etc.) are unchanged.
- Internal `None`-config fallbacks in `_setup.py` and `render.py` now build disabled placeholders via new `unset()` factories (an internal `_validate` `InitVar` escape hatch), so the no-config path keeps working without introducing org-specific defaults.
- Added `tests/test_config_validation.py` covering: empty/whitespace required values raise a field-named `ValueError`, valid construction works, and `unset()` placeholders skip validation.

## Examples now failing fast

```python
ArtifactStoreConfig(s3_bucket="")                       # ValueError: ArtifactStoreConfig.s3_bucket must not be empty
PackageRegistryConfig(domain="", domain_owner="", repository="x", region="us-east-1")
# ValueError: PackageRegistryConfig.domain_owner must not be empty
```

## Validation

- `uv run pytest -v` — 296 passed
- `uv run ruff check .` — all checks passed
- `uv run ruff format .` — clean

The unopinionated design is preserved: no baked-in buckets, domains, or other org defaults — empty required values are simply rejected.

Closes #34