### PR TITLE
[TEST] Add Airflow 2.11 leg to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,44 @@ jobs:
       - name: Run pytest
         run: uv run pytest -v
 
+  pytest-airflow2:
+    name: pytest (Airflow 2.11)
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read  # checkout only
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      # The committed lock pins Airflow 3.x. This leg instead pins Airflow 2.11
+      # via Airflow's official constraints so the 2.x compat branch (which
+      # downstream consumers run) is exercised. 2.11 supports Python 3.9-3.12,
+      # so it runs on 3.12. ruff is intentionally omitted (lint has its own
+      # workflow, and the 2.11 constraints pin ruff<0.6); only the test runners
+      # are installed, unconstrained, on top of the constrained runtime.
+      - name: Create Airflow 2.11 environment
+        run: |
+          uv venv --python 3.12
+          uv pip install -e ".[all]" "apache-airflow==2.11.*" \
+            --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.12.txt
+          uv pip install "pytest>=8.0" "pytest-mock>=3.12"
+
+      - name: Run pytest
+        run: .venv/bin/pytest -v
+
   all-pass:
     name: All pytest versions passed
     runs-on: ubuntu-slim
-    needs: pytest
+    needs: [pytest, pytest-airflow2]
     if: always()
     steps:
       - uses: lowlydba/are-we-good@bb8ee9e793e4233fac1992bb880e2a28bed7f42f # v1.0.3

--- a/tests/test_iceberg_config_templating.py
+++ b/tests/test_iceberg_config_templating.py
@@ -45,6 +45,10 @@ def _render(dag, op, bucket):
     context = {
         "ti": mock.MagicMock(),
         "task_instance": mock.MagicMock(),
+        # Airflow 2.x XComArg.resolve() reads this key for upstream map-index
+        # lookup; absent on the 3.x render path. Supplied here so the shared
+        # render path runs identically on both Airflow generations.
+        "expanded_ti_count": None,
         "var": SimpleNamespace(value=SimpleNamespace(managed_bucket_iceberg=bucket)),
     }
     op.render_template_fields(context, jinja_env=dag.get_template_env())


### PR DESCRIPTION
## Problem

CI exercised **Airflow 3.x only**, so the Airflow 2.x compat branch that downstream consumers (Airflow 2.11) run was never tested:

- `pyproject.toml` pins `apache-airflow>=2.11.0` — a floor, not a target.
- `uv.lock` (committed) locks `apache-airflow == 3.2.2`.
- `test.yml` ran `uv sync` (installs the locked 3.2.2) with a **Python-only** matrix — no Airflow-version axis.

So `_airflow_compat`'s 2.x imports (`airflow.models.xcom.XCom`, `airflow.models.baseoperatorlink.BaseOperatorLink`) and 2.x render behavior never ran in CI.

## Changes

- **`test.yml`**: add a `pytest (Airflow 2.11)` job that installs Airflow 2.11 via Airflow's official constraints file on Python 3.12 (2.11 supports 3.9–3.12), runs the full suite, and is wired into the `all-pass` gate. The existing locked-3.x matrix is untouched. `ruff` is omitted from this leg (lint has its own workflow, and the 2.11 constraints pin `ruff<0.6`); only the test runners are installed unconstrained on top of the constrained runtime.
- **`tests/test_iceberg_config_templating.py`**: the shared `_render` helper's mock context lacked `expanded_ti_count`, which Airflow 2.x `XComArg.resolve()` reads during template rendering (the 3.x render path does not). This caused 3 failures under 2.11 only. Supplying the key lets the render path run identically on both Airflow generations.

## Validation

Full suite run locally against both environments — **315 passed** on Airflow 2.11.0 (`AIRFLOW_MAJOR == 2`, `XCom` from `airflow.models.xcom`) and **315 passed** on the locked Airflow 3.2.2.

Closes #41

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>