### PR TITLE
[CHORE] V1 cleanup: rename PyPI dist, beta status, Databricks runner preflight

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,10 +1,10 @@
 ---
-# Publishes the overture-airflow-provider package in two scenarios:
+# Publishes the airflow-provider-overture package in two scenarios:
 #   1. Release (production): triggered when a GitHub Release is published → publishes to PyPI.
 #   2. Dry-run: triggered manually via workflow_dispatch → publishes to Test PyPI to verify
 #      the build and publish pipeline end-to-end without affecting the production package index.
 # Uses OIDC trusted publishing — no API token required.
-name: Publish overture-airflow-provider
+name: Publish airflow-provider-overture
 
 on:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-10
+
 ### Changed
 
 - **Renamed the published PyPI distribution from `overture-airflow-provider` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Renamed the published PyPI distribution from `overture-airflow-provider` to
+  `airflow-provider-overture`** to match the common Airflow third-party provider
+  naming convention. The import module (`overture_airflow_provider`) and the
+  GitHub repository are unchanged; only `pip install` and PyPI metadata differ.
+  ([#26](https://github.com/OvertureMaps/overture-airflow-provider/issues/26))
+- Bumped the package development status classifier from Alpha to Beta.
+  ([#28](https://github.com/OvertureMaps/overture-airflow-provider/issues/28))
+
+### Added
+
+- **Fail-fast preflight for the Databricks runner notebook.** Notebook jobs now
+  verify the bundled runner is deployed to the workspace before submitting and
+  raise an actionable error (pointing at
+  `upload_databricks_runner_to_workspace`) instead of failing opaquely mid-run.
+  Documented the one-time Databricks runner deploy step in the README.
+  ([#13](https://github.com/OvertureMaps/overture-airflow-provider/issues/13))
+
 ## [0.1.5] - 2026-06-03
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Use `[WIP]` as a prefix on repos without draft PR support.
 
 ## Publishing
 
-Package published to [PyPI](https://pypi.org/project/overture-airflow-provider/) via the
+Package published to [PyPI](https://pypi.org/project/airflow-provider-overture/) via the
 [`publish-pypi.yml`](.github/workflows/publish-pypi.yml) workflow using
 [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) — no API token needed.
 This repo, workflow, and GitHub environment must be pre-configured in PyPI and Test PyPI.
@@ -60,7 +60,7 @@ This repo, workflow, and GitHub environment must be pre-configured in PyPI and T
 ### Dry-run / Test PyPI
 
 Trigger the workflow manually via `workflow_dispatch` to publish to
-[Test PyPI](https://test.pypi.org/project/overture-airflow-provider/) instead of production.
+[Test PyPI](https://test.pypi.org/project/airflow-provider-overture/) instead of production.
 Useful for verifying the build and publish pipeline end-to-end. Uses `skip-existing: true`
 so version conflicts don't fail the run.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # overture-airflow-provider
 
+[![PyPI version](https://img.shields.io/pypi/v/airflow-provider-overture.svg)](https://pypi.org/project/airflow-provider-overture/)
+[![Python versions](https://img.shields.io/pypi/pyversions/airflow-provider-overture.svg)](https://pypi.org/project/airflow-provider-overture/)
+[![License: MIT](https://img.shields.io/pypi/l/airflow-provider-overture.svg)](LICENSE)
+
 An Apache Airflow provider exposing a **Spark-agnostic task group** that runs
 PySpark or Scala/Spark jobs on AWS Glue, Databricks, or Wherobots Cloud — from
 a single, unified DAG-level API.
@@ -19,15 +23,15 @@ organization.
 ## Install
 
 ```bash
-pip install overture-airflow-provider
+pip install airflow-provider-overture
 ```
 
 Optional extras for platforms that need extra SDKs:
 
 ```bash
-pip install "overture-airflow-provider[databricks]"
-pip install "overture-airflow-provider[wherobots]"
-pip install "overture-airflow-provider[all]"
+pip install "airflow-provider-overture[databricks]"
+pip install "airflow-provider-overture[wherobots]"
+pip install "airflow-provider-overture[all]"
 ```
 
 Requires Python `>=3.11` and Apache Airflow `>=2.11`.
@@ -125,6 +129,35 @@ that targets all three platforms.
 
 See [`SPEC.md`](SPEC.md) for the full architecture.
 
+## Databricks runner deployment
+
+Unlike Glue and Wherobots — whose bundled runner scripts are auto-uploaded to
+S3 during task-group setup — the **Databricks runner is a Workspace Notebook
+that must be deployed once, out-of-band**, before your first run. The provider
+references it at submit time but does not push it for you (notebook deployment
+needs Workspace API credentials many teams keep in CI/CD, not on Airflow
+workers).
+
+Deploy it via your CI/CD pipeline or the bundled helper:
+
+```python
+from overture_airflow_provider.runner_assets import (
+    upload_databricks_runner_to_workspace,
+)
+
+upload_databricks_runner_to_workspace(
+    databricks_host="https://my-workspace.cloud.databricks.com",
+    databricks_token="dapi...",  # PAT or CI/CD secret
+    # Must match DatabricksConfig.workspace_scripts_path_template (after
+    # {s3_assets_root} substitution) + "/job_runner_databricks".
+    workspace_path="/Workspace/Shared/<s3_assets_root>/job_runner_databricks",
+)
+```
+
+If the notebook is missing, the task group runs a **fail-fast preflight** during
+job execution and raises an actionable error instead of failing opaquely
+mid-run.
+
 ## Local rendering (testing without Airflow)
 
 The `overture_airflow_provider.render` module produces the exact platform
@@ -187,6 +220,3 @@ uv run ruff format --check .
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-## License
-
-MIT — see [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ value (S3 buckets, IAM roles, catalog endpoints, package registries) is passed
 in via typed config dataclasses. No defaults are baked in for any one
 organization.
 
-> Status: `0.1.0` — initial MVP. Unit + mock test coverage only; live-platform
+> Status: `0.2.0` — Beta. Unit + mock test coverage only; live-platform
 > E2E tests are tracked as a follow-up.
 
 ## Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["uv_build>=0.5"]
 build-backend = "uv_build"
 
 [project]
-name = "overture-airflow-provider"
+name = "airflow-provider-overture"
 version = "0.1.5"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Overture Maps Foundation" }]
 keywords = ["airflow", "spark", "glue", "databricks", "wherobots", "sedona", "iceberg"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Framework :: Apache Airflow",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
@@ -49,7 +49,7 @@ Documentation = "https://github.com/OvertureMaps/overture-airflow-provider#readm
 Issues = "https://github.com/OvertureMaps/overture-airflow-provider/issues"
 
 [project.entry-points."apache_airflow_provider"]
-overture-airflow-provider = "overture_airflow_provider.provider_info:get_provider_info"
+airflow-provider-overture = "overture_airflow_provider.provider_info:get_provider_info"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.1.5"
+version = "0.2.0"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/__init__.py
+++ b/src/overture_airflow_provider/__init__.py
@@ -19,7 +19,7 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any
 
 try:
-    __version__ = version("overture-airflow-provider")
+    __version__ = version("airflow-provider-overture")
 except PackageNotFoundError:  # package not installed (e.g. source checkout)
     __version__ = "0.0.0"
 

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -320,12 +320,12 @@ def setup_databricks_cluster(
 def _is_runner_not_found(exc: Exception) -> bool:
     """Identify a Databricks workspace "object does not exist" error.
 
-    Avoids importing the databricks-sdk error type (kept lazy / optional) by
-    matching on the exception class name and the SDK's ``error_code`` field.
+    The workspace ``get-status`` REST endpoint returns HTTP 404 when the path
+    is absent (matching how the official ``DatabricksHook.get_repo_by_path``
+    treats a missing object).
     """
-    if type(exc).__name__ in ("NotFound", "ResourceDoesNotExist"):
-        return True
-    return getattr(exc, "error_code", "") == "RESOURCE_DOES_NOT_EXIST"
+    response = getattr(exc, "response", None)
+    return getattr(response, "status_code", None) == 404
 
 
 def preflight_databricks_runner(setup_info: dict, cluster_info: dict) -> None:
@@ -337,19 +337,28 @@ def preflight_databricks_runner(setup_info: dict, cluster_info: dict) -> None:
     it's missing, the submit otherwise fails opaquely mid-run. This checks the
     resolved workspace path up front and raises an actionable error instead.
 
-    Best-effort: if the workspace can't be queried (missing ``[databricks]``
-    extra, auth, or permissions), a warning is printed and the check is skipped
-    so a working deployment is never turned into a hard failure on an edge-case
-    auth setup.
+    The check reuses the official ``DatabricksHook`` and the same
+    ``databricks_conn_id`` the submit uses, so preflight auth always matches the
+    job's auth (no false skips) and no extra dependency or credential surface is
+    introduced. It hits ``2.0/workspace/get-status`` — the same endpoint the
+    provider's own ``get_repo_by_path`` uses.
+
+    Best-effort: if the workspace can't be queried (auth, permissions, transient
+    HTTP error, or an SDK/provider mismatch), a warning is printed and the check
+    is skipped so a working deployment is never turned into a hard failure.
     """
     notebook_path = f"{cluster_info['databricks_deployed_scripts_path']}/job_runner_databricks"
     conn_id = cluster_info["databricks_conf"].get("databricks_conn_id", "databricks_default")
 
     try:
-        from overture_airflow_provider.hooks import DatabricksSdkHook
+        from airflow.providers.databricks.hooks.databricks import DatabricksHook
 
-        with DatabricksSdkHook(conn_id).get_workspace_client() as client:
-            client.workspace.get_status(notebook_path)
+        hook = DatabricksHook(databricks_conn_id=conn_id)
+        hook._do_api_call(
+            ("GET", "2.0/workspace/get-status"),
+            {"path": notebook_path},
+            wrap_http_errors=False,
+        )
     except Exception as exc:
         if _is_runner_not_found(exc):
             raise RuntimeError(

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -317,6 +317,55 @@ def setup_databricks_cluster(
     }
 
 
+def _is_runner_not_found(exc: Exception) -> bool:
+    """Identify a Databricks workspace "object does not exist" error.
+
+    Avoids importing the databricks-sdk error type (kept lazy / optional) by
+    matching on the exception class name and the SDK's ``error_code`` field.
+    """
+    if type(exc).__name__ in ("NotFound", "ResourceDoesNotExist"):
+        return True
+    return getattr(exc, "error_code", "") == "RESOURCE_DOES_NOT_EXIST"
+
+
+def preflight_databricks_runner(setup_info: dict, cluster_info: dict) -> None:
+    """Fail fast when the Databricks runner notebook is not deployed.
+
+    Unlike Glue/Wherobots — whose runners auto-upload to S3 during setup — the
+    Databricks runner is a Workspace Notebook that must be staged out-of-band
+    (CI/CD or :func:`runner_assets.upload_databricks_runner_to_workspace`). If
+    it's missing, the submit otherwise fails opaquely mid-run. This checks the
+    resolved workspace path up front and raises an actionable error instead.
+
+    Best-effort: if the workspace can't be queried (missing ``[databricks]``
+    extra, auth, or permissions), a warning is printed and the check is skipped
+    so a working deployment is never turned into a hard failure on an edge-case
+    auth setup.
+    """
+    notebook_path = f"{cluster_info['databricks_deployed_scripts_path']}/job_runner_databricks"
+    conn_id = cluster_info["databricks_conf"].get("databricks_conn_id", "databricks_default")
+
+    try:
+        from overture_airflow_provider.hooks import DatabricksSdkHook
+
+        with DatabricksSdkHook(conn_id).get_workspace_client() as client:
+            client.workspace.get_status(notebook_path)
+    except Exception as exc:
+        if _is_runner_not_found(exc):
+            raise RuntimeError(
+                f"Databricks runner notebook not found at {notebook_path!r}. Unlike "
+                "Glue and Wherobots, the Databricks runner is a Workspace Notebook that "
+                "must be deployed before the first run. Deploy it via your CI/CD pipeline "
+                "or overture_airflow_provider.runner_assets."
+                "upload_databricks_runner_to_workspace(...). See the README "
+                "'Databricks runner deployment' section."
+            ) from None
+        print(
+            f"[Databricks] WARNING: could not verify runner notebook at {notebook_path} "
+            f"({type(exc).__name__}: {exc}); proceeding without preflight"
+        )
+
+
 def build_databricks_operator_kwargs(
     setup_info: dict,
     cluster_info: dict,
@@ -403,6 +452,11 @@ def execute_databricks_job(
     from airflow.providers.databricks.operators.databricks import (
         DatabricksSubmitRunOperator,
     )
+
+    # Notebook jobs (module_name set) require the bundled runner notebook to be
+    # pre-deployed to the workspace; fail fast with guidance if it's missing.
+    if module_name:
+        preflight_databricks_runner(setup_info, cluster_info)
 
     built = build_databricks_operator_kwargs(
         setup_info=setup_info,

--- a/src/overture_airflow_provider/provider_info.py
+++ b/src/overture_airflow_provider/provider_info.py
@@ -13,7 +13,7 @@ from importlib.metadata import PackageNotFoundError, version
 def _package_version() -> str:
     """Resolve the installed package version, falling back when uninstalled."""
     try:
-        return version("overture-airflow-provider")
+        return version("airflow-provider-overture")
     except PackageNotFoundError:  # package not installed (e.g. source checkout)
         return "0.0.0"
 
@@ -21,11 +21,16 @@ def _package_version() -> str:
 def get_provider_info() -> dict:
     """Return Airflow provider metadata conforming to provider_info.schema.json."""
     return {
-        "package-name": "overture-airflow-provider",
+        "package-name": "airflow-provider-overture",
         "name": "Overture Maps Spark-agnostic Provider",
         "description": (
-            "Airflow TaskGroup for submitting Spark jobs to AWS Glue, Databricks, "
-            "or Wherobots Cloud from a single, platform-agnostic DAG entry point."
+            "Airflow TaskGroup for submitting Spark jobs to "
+            "`AWS Glue <https://docs.aws.amazon.com/glue/>`_, "
+            "`Databricks <https://docs.databricks.com/>`_, or "
+            "`Wherobots Cloud <https://docs.wherobots.com/>`_ from a single, "
+            "platform-agnostic DAG entry point. See the "
+            "`GitHub repository "
+            "<https://github.com/OvertureMaps/overture-airflow-provider>`_."
         ),
         "versions": [_package_version()],
         "operators": [

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -841,43 +841,67 @@ class TestDatabricksRunnerPreflight:
         "databricks_conf": {"databricks_conn_id": "databricks_default"},
         "databricks_deployed_scripts_path": "/Workspace/Shared/spark-agnostic-operator",
     }
+    _NOTEBOOK_PATH = "/Workspace/Shared/spark-agnostic-operator/job_runner_databricks"
 
     def test_passes_when_notebook_exists(self):
         from overture_airflow_provider._databricks import preflight_databricks_runner
 
-        mock_client = MagicMock()
         mock_hook = MagicMock()
-        mock_hook.get_workspace_client.return_value.__enter__.return_value = mock_client
+        mock_hook._do_api_call.return_value = {"object_type": "NOTEBOOK"}
 
-        with patch("overture_airflow_provider.hooks.DatabricksSdkHook", return_value=mock_hook):
+        with patch(
+            "airflow.providers.databricks.hooks.databricks.DatabricksHook",
+            return_value=mock_hook,
+        ):
             preflight_databricks_runner({}, self._CLUSTER_INFO)
 
-        mock_client.workspace.get_status.assert_called_once_with(
-            "/Workspace/Shared/spark-agnostic-operator/job_runner_databricks"
+        mock_hook._do_api_call.assert_called_once_with(
+            ("GET", "2.0/workspace/get-status"),
+            {"path": self._NOTEBOOK_PATH},
+            wrap_http_errors=False,
         )
 
     def test_raises_actionable_error_when_notebook_missing(self):
+        from requests.exceptions import HTTPError
+
         from overture_airflow_provider._databricks import preflight_databricks_runner
 
-        class ResourceDoesNotExist(Exception):
-            pass
-
-        mock_client = MagicMock()
-        mock_client.workspace.get_status.side_effect = ResourceDoesNotExist("nope")
         mock_hook = MagicMock()
-        mock_hook.get_workspace_client.return_value.__enter__.return_value = mock_client
+        mock_hook._do_api_call.side_effect = HTTPError(response=MagicMock(status_code=404))
 
-        with patch("overture_airflow_provider.hooks.DatabricksSdkHook", return_value=mock_hook):
+        with patch(
+            "airflow.providers.databricks.hooks.databricks.DatabricksHook",
+            return_value=mock_hook,
+        ):
             with pytest.raises(RuntimeError, match="runner notebook not found"):
                 preflight_databricks_runner({}, self._CLUSTER_INFO)
 
-    def test_warns_and_proceeds_on_other_errors(self, capsys):
+    def test_warns_and_proceeds_on_non_404_http_error(self, capsys):
+        from requests.exceptions import HTTPError
+
         from overture_airflow_provider._databricks import preflight_databricks_runner
 
         mock_hook = MagicMock()
-        mock_hook.get_workspace_client.side_effect = RuntimeError("auth boom")
+        mock_hook._do_api_call.side_effect = HTTPError(response=MagicMock(status_code=500))
 
-        with patch("overture_airflow_provider.hooks.DatabricksSdkHook", return_value=mock_hook):
+        with patch(
+            "airflow.providers.databricks.hooks.databricks.DatabricksHook",
+            return_value=mock_hook,
+        ):
+            preflight_databricks_runner({}, self._CLUSTER_INFO)
+
+        assert "could not verify runner notebook" in capsys.readouterr().out
+
+    def test_warns_and_proceeds_on_auth_error(self, capsys):
+        from overture_airflow_provider._databricks import preflight_databricks_runner
+
+        mock_hook = MagicMock()
+        mock_hook._do_api_call.side_effect = RuntimeError("auth boom")
+
+        with patch(
+            "airflow.providers.databricks.hooks.databricks.DatabricksHook",
+            return_value=mock_hook,
+        ):
             preflight_databricks_runner({}, self._CLUSTER_INFO)
 
         assert "could not verify runner notebook" in capsys.readouterr().out

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -762,6 +762,7 @@ class TestDatabricksExecuteJob:
                 "airflow.providers.databricks.hooks.databricks.DatabricksHook",
                 return_value=mock_hook,
             ),
+            patch("overture_airflow_provider._databricks.preflight_databricks_runner"),
         ):
             execute_databricks_job(
                 setup_info=setup_info,
@@ -817,6 +818,7 @@ class TestDatabricksExecuteJob:
                 "airflow.providers.databricks.hooks.databricks.DatabricksHook",
                 return_value=mock_hook,
             ),
+            patch("overture_airflow_provider._databricks.preflight_databricks_runner"),
         ):
             execute_databricks_job(
                 setup_info=setup_info,
@@ -832,6 +834,53 @@ class TestDatabricksExecuteJob:
         calls = context["ti"].xcom_push.call_args_list
         spark_agnostic_calls = [c for c in calls if c.kwargs.get("key") == "spark_agnostic"]
         assert spark_agnostic_calls
+
+
+class TestDatabricksRunnerPreflight:
+    _CLUSTER_INFO = {
+        "databricks_conf": {"databricks_conn_id": "databricks_default"},
+        "databricks_deployed_scripts_path": "/Workspace/Shared/spark-agnostic-operator",
+    }
+
+    def test_passes_when_notebook_exists(self):
+        from overture_airflow_provider._databricks import preflight_databricks_runner
+
+        mock_client = MagicMock()
+        mock_hook = MagicMock()
+        mock_hook.get_workspace_client.return_value.__enter__.return_value = mock_client
+
+        with patch("overture_airflow_provider.hooks.DatabricksSdkHook", return_value=mock_hook):
+            preflight_databricks_runner({}, self._CLUSTER_INFO)
+
+        mock_client.workspace.get_status.assert_called_once_with(
+            "/Workspace/Shared/spark-agnostic-operator/job_runner_databricks"
+        )
+
+    def test_raises_actionable_error_when_notebook_missing(self):
+        from overture_airflow_provider._databricks import preflight_databricks_runner
+
+        class ResourceDoesNotExist(Exception):
+            pass
+
+        mock_client = MagicMock()
+        mock_client.workspace.get_status.side_effect = ResourceDoesNotExist("nope")
+        mock_hook = MagicMock()
+        mock_hook.get_workspace_client.return_value.__enter__.return_value = mock_client
+
+        with patch("overture_airflow_provider.hooks.DatabricksSdkHook", return_value=mock_hook):
+            with pytest.raises(RuntimeError, match="runner notebook not found"):
+                preflight_databricks_runner({}, self._CLUSTER_INFO)
+
+    def test_warns_and_proceeds_on_other_errors(self, capsys):
+        from overture_airflow_provider._databricks import preflight_databricks_runner
+
+        mock_hook = MagicMock()
+        mock_hook.get_workspace_client.side_effect = RuntimeError("auth boom")
+
+        with patch("overture_airflow_provider.hooks.DatabricksSdkHook", return_value=mock_hook):
+            preflight_databricks_runner({}, self._CLUSTER_INFO)
+
+        assert "could not verify runner notebook" in capsys.readouterr().out
 
 
 class TestWherobotsSetupCluster:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,7 +7,7 @@ from overture_airflow_provider.provider_info import get_provider_info
 
 
 def test_version_matches_installed_metadata():
-    assert overture_airflow_provider.__version__ == version("overture-airflow-provider")
+    assert overture_airflow_provider.__version__ == version("airflow-provider-overture")
 
 
 def test_provider_info_versions_match_package_version():


### PR DESCRIPTION
Resolves #28 and #26, and addresses #13 (docs + fail-fast preflight).

## #28 — V1 cleanup
- pyproject: `Development Status :: 3 - Alpha` → `4 - Beta`
- README: removed the redundant `## License` section; added PyPI / Python-versions / license badges
- `provider_info.py`: rST hyperlinks in the provider `description` (AWS Glue, Databricks, Wherobots docs + GitHub repo)

## #26 — Rename PyPI distribution
Renamed the **published distribution** `overture-airflow-provider` → `airflow-provider-overture` (matches the common Airflow third-party provider convention). The import module `overture_airflow_provider` and the GitHub repo are **unchanged** — can be revisited internally later.
- pyproject `name` + entry-point key
- `version()` lookups (`__init__`, `provider_info`), `package-name`
- README install commands + badges, CONTRIBUTING PyPI links, publish workflow name
- `test_version.py`

## #13 — Databricks runner discoverability (options 1 + 3)
- **Fail-fast preflight:** notebook jobs verify the bundled runner notebook is deployed to the workspace before submit and raise an actionable error pointing at `upload_databricks_runner_to_workspace(...)`, instead of failing opaquely mid-run. Best-effort: warns and proceeds when the workspace can't be queried (missing extra / auth / permissions) so a working deploy is never turned into a hard failure.
- **Docs:** new README "Databricks runner deployment" section calling out the one-time out-of-band deploy step.

Opt-in auto-deploy (option 2) intentionally left out per discussion.

## Verification
- `uv run pytest` → 318 passed (incl. new preflight tests)
- `uv run ruff check .` + `ruff format --check .` → clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>