### PR TITLE
[BUG] Forward extra_spark_conf to SparkSedonaJob via init_spark_for_platform in Glue runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-12
+
+### Fixed
+
+- **Glue runner now forwards `extra_spark_conf` to `SparkSedonaJob`-style jobs.**
+  Previously, jobs whose `run()` does not accept a `spark` argument (e.g.
+  `SparkSedonaJob` subclasses that initialise Spark internally) silently
+  discarded all DAG-level `extra_spark_conf` entries. The runner now detects
+  `init_spark_for_platform` on the instance and calls it with the extra conf
+  before `run()`, so builder-time settings (Iceberg catalog registrations, etc.)
+  are applied correctly.
+  ([#51](https://github.com/OvertureMaps/overture-airflow-provider/issues/51))
+
 ## [0.3.0] - 2026-06-10
 
 ### Changed
@@ -67,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   defers, polls, and resumes correctly regardless. This provider deliberately
   reuses the installed provider's trigger (to always match the installed
   version), so it does not fork the trigger to silence the message.
+## [0.2.0] - 2026-06-10
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.3.0"
+version = "0.3.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/runners/job_runner_glue.py
+++ b/src/overture_airflow_provider/runners/job_runner_glue.py
@@ -9,8 +9,10 @@ Args (resolved via ``awsglue.utils.getResolvedOptions``):
     class_name: Class name to instantiate and call ``.run()``.
     params: JSON-encoded parameters forwarded verbatim to the job class.
     extra_spark_conf: JSON-encoded dict of additional SparkConf key/value pairs.
-        Applied to the current SparkSession when the job's ``run()`` accepts a
-        ``spark`` keyword argument.
+        Applied before ``run()`` in one of two ways: injected directly into the
+        active ``SparkSession`` when ``run()`` accepts a ``spark`` keyword
+        argument, or forwarded to ``init_spark_for_platform()`` for
+        ``SparkSedonaJob``-style classes that initialise Spark internally.
 """
 
 import inspect
@@ -45,7 +47,10 @@ job_cls = getattr(module, class_name)
 instance = job_cls()
 
 # Inject SparkSession only if the job's run() explicitly accepts it.
-# Legacy SparkSedonaJob classes call init_spark_for_platform() internally.
+# For SparkSedonaJob-style classes (no 'spark' param), pre-call
+# init_spark_for_platform() so extra_spark_conf reaches the Spark builder
+# before getOrCreate(). Without this, run() calls it internally with "{}"
+# and silently discards all DAG-level extra_spark_conf.
 run_kwargs: dict = {"params": params}
 sig = inspect.signature(instance.run)
 if "spark" in sig.parameters:
@@ -55,6 +60,8 @@ if "spark" in sig.parameters:
     for k, v in json.loads(extra_spark_conf_raw).items():
         spark.conf.set(k, v)
     run_kwargs["spark"] = spark
+elif hasattr(instance, "init_spark_for_platform"):
+    instance.init_spark_for_platform(extra_spark_conf=extra_spark_conf_raw)
 
 result = instance.run(**run_kwargs)
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -97,6 +97,22 @@ def test_glue_runner_uses_getResolvedOptions():
     assert "getResolvedOptions" in source
 
 
+def test_glue_runner_calls_init_spark_for_platform_for_sedona_jobs():
+    """SparkSedonaJob-style dispatch: extra_spark_conf forwarded via init_spark_for_platform."""
+    p = get_runner_path("glue")
+    source = p.read_text(encoding="utf-8")
+    assert "init_spark_for_platform" in source
+    assert "extra_spark_conf=extra_spark_conf_raw" in source
+
+
+def test_glue_runner_sedona_path_does_not_inject_spark_kwarg():
+    """The elif branch must not pass spark= to run() for SparkSedonaJob-style jobs."""
+    p = get_runner_path("glue")
+    source = p.read_text(encoding="utf-8")
+    # The SparkSedonaJob path must be an elif, not nested inside the spark-injection block.
+    assert "elif hasattr(instance, \"init_spark_for_platform\"):" in source
+
+
 def test_databricks_runner_dual_mode():
     p = get_runner_path("databricks")
     source = p.read_text(encoding="utf-8")

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -110,7 +110,7 @@ def test_glue_runner_sedona_path_does_not_inject_spark_kwarg():
     p = get_runner_path("glue")
     source = p.read_text(encoding="utf-8")
     # The SparkSedonaJob path must be an elif, not nested inside the spark-injection block.
-    assert "elif hasattr(instance, \"init_spark_for_platform\"):" in source
+    assert 'elif hasattr(instance, "init_spark_for_platform"):' in source
 
 
 def test_databricks_runner_dual_mode():


### PR DESCRIPTION
Fixes #51

`SparkSedonaJob` subclasses don't accept `spark` in `run()`, so the old runner skipped `extra_spark_conf` entirely. DAG-level catalog configs never reached `spark.conf`.

**Fix:** `elif hasattr(instance, "init_spark_for_platform")` branch calls it with `extra_spark_conf` before `run()`, so builder-time configs (catalogs, etc.) are applied. Existing `run(spark=...)` jobs unchanged.