### PR TITLE
[BUG] Remove malformed RST links from provider description

### DIFF
--- a/src/overture_airflow_provider/provider_info.py
+++ b/src/overture_airflow_provider/provider_info.py
@@ -24,13 +24,8 @@ def get_provider_info() -> dict:
         "package-name": "airflow-provider-overture",
         "name": "Overture Maps Spark-agnostic Provider",
         "description": (
-            "Airflow TaskGroup for submitting Spark jobs to "
-            "`AWS Glue <https://docs.aws.amazon.com/glue/>`__, "
-            "`Databricks <https://docs.databricks.com/>`__, or "
-            "`Wherobots Cloud <https://docs.wherobots.com/>`__ from a single, "
-            "platform-agnostic DAG entry point. See the "
-            "`GitHub repository "
-            "<https://github.com/OvertureMaps/overture-airflow-provider>`__."
+            "Spark-agnostic Airflow TaskGroup for submitting PySpark and Scala jobs to "
+            "AWS Glue, Databricks, or Wherobots Cloud from a single platform-agnostic DAG entry point."
         ),
         "versions": [_package_version()],
         "operators": [


### PR DESCRIPTION
Fixes #53

## What

Replaces the RST hyperlink syntax in `get_provider_info()` description with plain text.

## Why

The description mixed prose with multiple inline RST links, including one split across two string literals. This rendered incorrectly in some Airflow versions — producing literal RST markup or collapsing all links into a single malformed `<a>` tag.

Plain text is the pattern used by the majority of Apache Airflow first-party providers (Databricks, Snowflake, PostgreSQL, Celery, etc.). The `integrations` block already carries the canonical doc URLs for each platform.