### PR TITLE
[BUG] Inject Wherobots catalog credentials for S3 Tables, not just default catalog

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -122,20 +122,55 @@ side.
   (`...catalog-impl = GlueCatalog`, plus account-id), since the Wherobots
   runtime does not support the REST catalog client.
 
-The task group picks the variant at runtime based on `spark_family_name`.
+Each variant also has an S3 Tables counterpart (`s3tables_spark_config`,
+`wherobots_s3tables_spark_config`) for an optional, coexisting S3 Tables
+catalog under a distinct alias.
+
+`iceberg.resolve_iceberg_spark_config(iceberg_config, spark_family)` is the
+single place that picks the right variant pair for the resolved platform
+family and merges primary + S3 Tables into one dict (S3 Tables wins on key
+collision). Both the live DAG path (`spark_agnostic_taskgroup.py`) and the
+Airflow-free render path (`render.py`) call this one function — it used to be
+duplicated between them, which is how the Wherobots S3 Tables credential bug
+below went unnoticed for a release.
+
+## Spark config merge layers
+
+Three platforms, three merge points, one shared primitive
+(`spark_platform_handlers._merge_spark_conf(defaults, middle, extra)` — later
+args win):
+
+- **Glue**: `_GLUE_DATABRICKS_DEFAULTS` → Iceberg → `extra_spark_conf`, done
+  once in `GluePlatformHandler.setup_cluster`.
+- **Databricks**: two merges. `DatabricksPlatformHandler.setup_cluster` does
+  `_GLUE_DATABRICKS_DEFAULTS` → Iceberg → `extra_spark_conf` (same as Glue),
+  then `setup_databricks_cluster` (`_databricks.py`) does a second merge —
+  Databricks-specific Spark defaults (Sedona serde, Iceberg extensions,
+  commit protocol) → `DatabricksConfig.cluster_conf`'s `databricks_spark_conf`
+  → the already-merged conf from the first pass — via the same
+  `_merge_spark_conf` helper, so both Databricks layers and the Glue/Wherobots
+  layer share one precedence rule instead of a bespoke dict splat.
+- **Wherobots**: `_WHEROBOTS_DEFAULTS` → Iceberg → `extra_spark_conf` in
+  `WherobotsPlatformHandler.setup_cluster`, followed by a Wherobots-only
+  post-merge mutation pass in `_wherobots.build_wherobots_operator_kwargs`
+  (see below) that runs *after* the shared merge and is invisible from the
+  taskgroup/render call sites.
 
 ## Wherobots specifics
 
-- Wherobots strips a fixed list of unsupported spark-conf keys at execute
-  time (`extraJavaOptions`, `sedona.join.numpartition`, `kryoserializer.buffer`,
-  `maxResultSize`, `partitionOverwriteMode`).
-- When Iceberg is enabled, the Wherobots handler injects the Wherobots
-  credential factory config for **every** registered catalog (every
-  `spark.sql.catalog.<name>` key in the merged conf) so the Wherobots-managed
-  pod can assume the customer's role for each one — not just the catalog
-  named by `spark.sql.defaultCatalog`. This is what lets the S3 Tables
-  catalog (`wherobots_s3tables_spark_config`) authenticate correctly whether
-  it coexists with a primary catalog or is the only catalog configured.
+- `_wherobots._strip_unsupported_wherobots_keys` drops a fixed list of
+  unsupported spark-conf keys at execute time (`extraJavaOptions`,
+  `sedona.join.numpartition`, `kryoserializer.buffer`, `maxResultSize`,
+  `partitionOverwriteMode`).
+- `_wherobots._inject_wherobots_catalog_credentials` — when Iceberg is
+  enabled, injects the Wherobots credential factory config for **every**
+  registered catalog (via `spark_platform_handlers.registered_catalog_names`,
+  which scans `spark.sql.catalog.<name>` keys plus `spark.sql.defaultCatalog`)
+  so the Wherobots-managed pod can assume the customer's role for each one —
+  not just the catalog named by `spark.sql.defaultCatalog`. This is what lets
+  the S3 Tables catalog (`wherobots_s3tables_spark_config`) authenticate
+  correctly whether it coexists with a primary catalog or is the only catalog
+  configured.
 
 ## Failure enrichment
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -129,9 +129,13 @@ The task group picks the variant at runtime based on `spark_family_name`.
 - Wherobots strips a fixed list of unsupported spark-conf keys at execute
   time (`extraJavaOptions`, `sedona.join.numpartition`, `kryoserializer.buffer`,
   `maxResultSize`, `partitionOverwriteMode`).
-- When Iceberg is enabled (i.e. `spark.sql.defaultCatalog` is in the merged
-  conf), the Wherobots handler also injects the Wherobots credential factory
-  config so the Wherobots-managed pod can assume the customer's Glue role.
+- When Iceberg is enabled, the Wherobots handler injects the Wherobots
+  credential factory config for **every** registered catalog (every
+  `spark.sql.catalog.<name>` key in the merged conf) so the Wherobots-managed
+  pod can assume the customer's role for each one — not just the catalog
+  named by `spark.sql.defaultCatalog`. This is what lets the S3 Tables
+  catalog (`wherobots_s3tables_spark_config`) authenticate correctly whether
+  it coexists with a primary catalog or is the only catalog configured.
 
 ## Failure enrichment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.5.0"
+version = "0.5.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -3,9 +3,31 @@
 import json
 
 from overture_airflow_provider.cluster_sizing import DatabricksClusterSize
+from overture_airflow_provider.spark_platform_handlers import _merge_spark_conf
 
 # Default DBFS prefix used when callers pass bare jar filenames (no scheme).
 _DEFAULT_DBFS_JAR_PREFIX = "dbfs:/FileStore/deploy/"
+
+# Databricks-specific Spark defaults (Sedona serde, Iceberg extensions, commit
+# protocol). Merged with `_merge_spark_conf` so precedence — these defaults,
+# then the caller's `DatabricksConfig.cluster_conf["spark_conf"]`, then
+# `extra_spark_conf` (which already carries the shared Glue/Databricks
+# defaults + Iceberg config merged in by `DatabricksPlatformHandler.setup_cluster`)
+# — matches the same later-wins rule used by Glue and Wherobots.
+_DATABRICKS_SPARK_CONF_DEFAULTS = {
+    "parquet.enable.summary-metadata": "false",
+    "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
+    "spark.kryo.registrator": "org.apache.sedona.core.serde.SedonaKryoRegistrator",
+    "mapreduce.fileoutputcommitter.marksuccessfuljobs": "false",
+    "spark.sql.sources.commitProtocolClass": (
+        "org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol"
+    ),
+    "spark.sql.extensions": (
+        "org.apache.sedona.viz.sql.SedonaVizExtensions,org.apache.sedona.sql.SedonaSqlExtensions"
+    ),
+    "spark.databricks.io.directoryCommit.createSuccessFile": "false",
+}
+
 
 # See https://iceberg.apache.org/releases
 _SPARK_TO_ICEBERG_VERSION_MAP = {
@@ -277,22 +299,9 @@ def setup_databricks_cluster(
             driver_node_type=node_config["driver_node_type"],
         ),
         "spark_version": (node_config["spark_version"] or spark_impl.get_native_version()),
-        "spark_conf": {
-            "parquet.enable.summary-metadata": "false",
-            "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
-            "spark.kryo.registrator": "org.apache.sedona.core.serde.SedonaKryoRegistrator",
-            "mapreduce.fileoutputcommitter.marksuccessfuljobs": "false",
-            "spark.sql.sources.commitProtocolClass": (
-                "org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol"
-            ),
-            "spark.sql.extensions": (
-                "org.apache.sedona.viz.sql.SedonaVizExtensions,"
-                "org.apache.sedona.sql.SedonaSqlExtensions"
-            ),
-            "spark.databricks.io.directoryCommit.createSuccessFile": "false",
-            **databricks_spark_conf,
-            **extra_spark_conf,
-        },
+        "spark_conf": _merge_spark_conf(
+            _DATABRICKS_SPARK_CONF_DEFAULTS, databricks_spark_conf, extra_spark_conf
+        ),
         "azure_attributes": {
             "first_on_demand": 1,
             "availability": "ON_DEMAND_AZURE",

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -6,6 +6,7 @@ import shutil
 
 from overture_airflow_provider.cluster_sizing import WherobotsClusterSize
 from overture_airflow_provider.spark_agnostic_helpers import SparkAgnosticHelper
+from overture_airflow_provider.spark_platform_handlers import registered_catalog_names
 
 # Optional dependency: Wherobots SDK isn't installed in every environment.
 try:
@@ -189,6 +190,78 @@ def download_jars_wherobots(
     }
 
 
+_UNSUPPORTED_WHEROBOTS_KEYS = (
+    "spark.driver.extraJavaOptions",
+    "spark.executor.extraJavaOptions",
+    "sedona.join.numpartition",
+    "spark.kryoserializer.buffer",
+    "spark.driver.maxResultSize",
+    "spark.sql.sources.partitionOverwriteMode",
+)
+
+
+def _strip_unsupported_wherobots_keys(spark_configs: dict) -> dict:
+    """Drop Spark keys the Wherobots-managed runtime doesn't support.
+
+    Wherobots controls these settings itself (JVM options, Sedona partitioning,
+    serializer buffers, etc.), so passing them through would either be ignored
+    or conflict with the managed runtime. Returns a new dict; input is not
+    mutated.
+    """
+    return {k: v for k, v in spark_configs.items() if k not in _UNSUPPORTED_WHEROBOTS_KEYS}
+
+
+def _inject_wherobots_catalog_credentials(
+    spark_configs: dict,
+    wherobots_role_arn: str,
+    setup_info: dict,
+) -> dict:
+    """Add Wherobots credential delegation for every registered Iceberg catalog.
+
+    Every registered Iceberg catalog (the primary/default catalog *and* any
+    coexisting S3 Tables catalog) needs Wherobots credential delegation so the
+    Wherobots-managed pod can assume the customer's role for that catalog.
+    Scanning for all registered catalogs - rather than only
+    ``spark.sql.defaultCatalog`` - ensures a second catalog (e.g.
+    ``s3tables_catalog`` from ``wherobots_s3tables_spark_config``) gets the
+    same delegation as the default catalog, including when it is the only
+    catalog configured (no ``spark.sql.defaultCatalog`` set at all).
+
+    Raises ``ValueError`` if any catalog is registered but ``wherobots_role_arn``
+    is unset. Returns a new dict; input is not mutated.
+    """
+    catalog_names = registered_catalog_names(spark_configs)
+    if not catalog_names:
+        return dict(spark_configs)
+
+    if not wherobots_role_arn:
+        raise ValueError(
+            "WherobotsConfig.role_arn is required when using Iceberg with Wherobots. "
+            'Set it via: WherobotsConfig(role_arn="arn:aws:iam::<account>:role/<role-name>", ...)'
+        )
+
+    spark_configs = dict(spark_configs)
+    for catalog_name in catalog_names:
+        spark_configs.update(
+            {
+                f"spark.sql.catalog.{catalog_name}.client.factory": "com.wherobots.iceberg.aws.WherobotsStIntCredentialsFactory",
+                f"spark.sql.catalog.{catalog_name}.client.assume-role.arn": wherobots_role_arn,
+                f"spark.sql.catalog.{catalog_name}.client.assume-role.region": setup_info[
+                    "aws_region"
+                ],
+                f"spark.sql.catalog.{catalog_name}.client.credentials-provider": WHEROBOTS_PROVIDER,
+                f"spark.sql.catalog.{catalog_name}.client.credentials-provider.role-arn": wherobots_role_arn,
+                f"spark.sql.catalog.{catalog_name}.client.credentials-provider.external-id": setup_info[
+                    "wherobots_external_id"
+                ],
+                f"spark.sql.catalog.{catalog_name}.client.assume-role.external-id": setup_info[
+                    "wherobots_external_id"
+                ],
+            }
+        )
+    return spark_configs
+
+
 def build_wherobots_operator_kwargs(
     setup_info: dict,
     package_info: dict,
@@ -249,59 +322,10 @@ def build_wherobots_operator_kwargs(
 
     spark_configs = {k: str(v) for k, v in spark_configs.items()}
 
-    for cfg in (
-        "spark.driver.extraJavaOptions",
-        "spark.executor.extraJavaOptions",
-        "sedona.join.numpartition",
-        "spark.kryoserializer.buffer",
-        "spark.driver.maxResultSize",
-        "spark.sql.sources.partitionOverwriteMode",
-    ):
-        spark_configs.pop(cfg, None)
-
-    # Every registered Iceberg catalog (the primary/default catalog *and* any
-    # coexisting S3 Tables catalog) needs Wherobots credential delegation so
-    # the Wherobots-managed pod can assume the customer's role for that
-    # catalog. A catalog is "registered" by its top-level
-    # ``spark.sql.catalog.<name>`` key (the SparkCatalog class), distinct from
-    # that catalog's dotted sub-keys (``...catalog-impl``, ``...warehouse``,
-    # etc.). Scanning for all such keys - rather than only
-    # ``spark.sql.defaultCatalog`` - ensures a second catalog (e.g.
-    # ``s3tables_catalog`` from ``wherobots_s3tables_spark_config``) gets the
-    # same delegation as the default catalog, including when it is the only
-    # catalog configured (no ``spark.sql.defaultCatalog`` set at all).
-    catalog_names = {
-        match.group(1)
-        for key in spark_configs
-        if (match := re.fullmatch(r"spark\.sql\.catalog\.([^.]+)", key))
-    }
-    if "spark.sql.defaultCatalog" in spark_configs:
-        catalog_names.add(spark_configs["spark.sql.defaultCatalog"])
-
-    if catalog_names:
-        if not wherobots_role_arn:
-            raise ValueError(
-                "WherobotsConfig.role_arn is required when using Iceberg with Wherobots. "
-                'Set it via: WherobotsConfig(role_arn="arn:aws:iam::<account>:role/<role-name>", ...)'
-            )
-        for catalog_name in catalog_names:
-            spark_configs.update(
-                {
-                    f"spark.sql.catalog.{catalog_name}.client.factory": "com.wherobots.iceberg.aws.WherobotsStIntCredentialsFactory",
-                    f"spark.sql.catalog.{catalog_name}.client.assume-role.arn": wherobots_role_arn,
-                    f"spark.sql.catalog.{catalog_name}.client.assume-role.region": setup_info[
-                        "aws_region"
-                    ],
-                    f"spark.sql.catalog.{catalog_name}.client.credentials-provider": WHEROBOTS_PROVIDER,
-                    f"spark.sql.catalog.{catalog_name}.client.credentials-provider.role-arn": wherobots_role_arn,
-                    f"spark.sql.catalog.{catalog_name}.client.credentials-provider.external-id": setup_info[
-                        "wherobots_external_id"
-                    ],
-                    f"spark.sql.catalog.{catalog_name}.client.assume-role.external-id": setup_info[
-                        "wherobots_external_id"
-                    ],
-                }
-            )
+    spark_configs = _strip_unsupported_wherobots_keys(spark_configs)
+    spark_configs = _inject_wherobots_catalog_credentials(
+        spark_configs, wherobots_role_arn, setup_info
+    )
 
     runtime_name = ""
     if spark_cluster_size:

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -259,30 +259,49 @@ def build_wherobots_operator_kwargs(
     ):
         spark_configs.pop(cfg, None)
 
+    # Every registered Iceberg catalog (the primary/default catalog *and* any
+    # coexisting S3 Tables catalog) needs Wherobots credential delegation so
+    # the Wherobots-managed pod can assume the customer's role for that
+    # catalog. A catalog is "registered" by its top-level
+    # ``spark.sql.catalog.<name>`` key (the SparkCatalog class), distinct from
+    # that catalog's dotted sub-keys (``...catalog-impl``, ``...warehouse``,
+    # etc.). Scanning for all such keys - rather than only
+    # ``spark.sql.defaultCatalog`` - ensures a second catalog (e.g.
+    # ``s3tables_catalog`` from ``wherobots_s3tables_spark_config``) gets the
+    # same delegation as the default catalog, including when it is the only
+    # catalog configured (no ``spark.sql.defaultCatalog`` set at all).
+    catalog_names = {
+        match.group(1)
+        for key in spark_configs
+        if (match := re.fullmatch(r"spark\.sql\.catalog\.([^.]+)", key))
+    }
     if "spark.sql.defaultCatalog" in spark_configs:
+        catalog_names.add(spark_configs["spark.sql.defaultCatalog"])
+
+    if catalog_names:
         if not wherobots_role_arn:
             raise ValueError(
                 "WherobotsConfig.role_arn is required when using Iceberg with Wherobots. "
                 'Set it via: WherobotsConfig(role_arn="arn:aws:iam::<account>:role/<role-name>", ...)'
             )
-        catalog_name = spark_configs["spark.sql.defaultCatalog"]
-        spark_configs.update(
-            {
-                f"spark.sql.catalog.{catalog_name}.client.factory": "com.wherobots.iceberg.aws.WherobotsStIntCredentialsFactory",
-                f"spark.sql.catalog.{catalog_name}.client.assume-role.arn": wherobots_role_arn,
-                f"spark.sql.catalog.{catalog_name}.client.assume-role.region": setup_info[
-                    "aws_region"
-                ],
-                f"spark.sql.catalog.{catalog_name}.client.credentials-provider": WHEROBOTS_PROVIDER,
-                f"spark.sql.catalog.{catalog_name}.client.credentials-provider.role-arn": wherobots_role_arn,
-                f"spark.sql.catalog.{catalog_name}.client.credentials-provider.external-id": setup_info[
-                    "wherobots_external_id"
-                ],
-                f"spark.sql.catalog.{catalog_name}.client.assume-role.external-id": setup_info[
-                    "wherobots_external_id"
-                ],
-            }
-        )
+        for catalog_name in catalog_names:
+            spark_configs.update(
+                {
+                    f"spark.sql.catalog.{catalog_name}.client.factory": "com.wherobots.iceberg.aws.WherobotsStIntCredentialsFactory",
+                    f"spark.sql.catalog.{catalog_name}.client.assume-role.arn": wherobots_role_arn,
+                    f"spark.sql.catalog.{catalog_name}.client.assume-role.region": setup_info[
+                        "aws_region"
+                    ],
+                    f"spark.sql.catalog.{catalog_name}.client.credentials-provider": WHEROBOTS_PROVIDER,
+                    f"spark.sql.catalog.{catalog_name}.client.credentials-provider.role-arn": wherobots_role_arn,
+                    f"spark.sql.catalog.{catalog_name}.client.credentials-provider.external-id": setup_info[
+                        "wherobots_external_id"
+                    ],
+                    f"spark.sql.catalog.{catalog_name}.client.assume-role.external-id": setup_info[
+                        "wherobots_external_id"
+                    ],
+                }
+            )
 
     runtime_name = ""
     if spark_cluster_size:

--- a/src/overture_airflow_provider/iceberg.py
+++ b/src/overture_airflow_provider/iceberg.py
@@ -1,0 +1,84 @@
+"""Single source of truth for picking and merging Iceberg Spark configs.
+
+``IcebergConfig`` (see ``config.py``) carries four JSON-string fields because
+each platform family talks to Iceberg differently, and an S3 Tables catalog
+can optionally coexist alongside the primary one:
+
+- ``spark_config`` / ``wherobots_spark_config`` — the primary catalog, Glue
+  and Databricks vs. Wherobots respectively.
+- ``s3tables_spark_config`` / ``wherobots_s3tables_spark_config`` — the
+  optional secondary S3 Tables catalog for the same two platform groups.
+
+``resolve_iceberg_spark_config`` is the *only* place that picks the right pair
+for a resolved platform family and merges them. It used to be duplicated
+(nearly verbatim) between ``spark_agnostic_taskgroup._select_iceberg_conf``
+(the live DAG path) and ``render._select_iceberg_spark_config`` (the
+Airflow-free render/test path). Two copies meant a fix to one could silently
+miss the other; both now delegate here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from overture_airflow_provider.config import IcebergConfig, coerce_config_dict
+
+if TYPE_CHECKING:
+    from overture_airflow_provider.spark import SparkFamily
+
+WHEROBOTS_FAMILY_NAME = "WHEROBOTS"
+
+
+def _family_name(spark_family: SparkFamily | str) -> str:
+    """Normalize a ``SparkFamily`` enum member or a bare family name string."""
+    return spark_family.name if hasattr(spark_family, "name") else str(spark_family)
+
+
+def resolve_iceberg_spark_config(
+    iceberg_config: IcebergConfig | None,
+    spark_family: SparkFamily | str,
+) -> dict[str, Any]:
+    """Pick the right Iceberg config variants for ``spark_family`` and merge them.
+
+    Merges the primary catalog config with the S3 Tables catalog config (when
+    present) into a single dict. S3 Tables keys are namespaced under a separate
+    catalog alias (e.g. ``spark.sql.catalog.s3tables_catalog.*``) so they
+    coexist with the primary catalog without conflicting; S3 Tables values win
+    over primary-catalog values on key collision.
+
+    Args:
+        iceberg_config: The caller's ``IcebergConfig``, or ``None`` if the job
+            doesn't use Iceberg.
+        spark_family: The resolved platform family, as a ``SparkFamily`` enum
+            member or its bare name (e.g. ``"WHEROBOTS"``) — both call sites
+            (the live DAG path and the Airflow-free render path) resolve the
+            family at a different point in their pipeline, so both shapes are
+            accepted rather than forcing one to convert.
+
+    Returns:
+        The merged Spark config dict. Empty when ``iceberg_config`` is
+        ``None`` or all its relevant fields are unset.
+    """
+    if iceberg_config is None:
+        return {}
+
+    if _family_name(spark_family) == WHEROBOTS_FAMILY_NAME:
+        primary = coerce_config_dict(
+            iceberg_config.wherobots_spark_config,
+            field_name="IcebergConfig.wherobots_spark_config",
+        )
+        s3tables = coerce_config_dict(
+            iceberg_config.wherobots_s3tables_spark_config,
+            field_name="IcebergConfig.wherobots_s3tables_spark_config",
+        )
+    else:
+        primary = coerce_config_dict(
+            iceberg_config.spark_config,
+            field_name="IcebergConfig.spark_config",
+        )
+        s3tables = coerce_config_dict(
+            iceberg_config.s3tables_spark_config,
+            field_name="IcebergConfig.s3tables_spark_config",
+        )
+
+    return {**primary, **s3tables}

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -41,8 +41,8 @@ from overture_airflow_provider.config import (
     IcebergConfig,
     PackageRegistryConfig,
     WherobotsConfig,
-    coerce_config_dict,
 )
+from overture_airflow_provider.iceberg import resolve_iceberg_spark_config
 from overture_airflow_provider.runner_assets import _RUNNER_FILES, _file_sha256, get_runner_path
 from overture_airflow_provider.spark import SparkFamily, SparkImpl, SparkSedona
 from overture_airflow_provider.spark_platform_handlers import (
@@ -125,32 +125,6 @@ def _jsonify(obj: Any) -> Any:
     if hasattr(obj, "name") and hasattr(obj, "value"):
         return obj.name
     return obj
-
-
-def _select_iceberg_spark_config(
-    iceberg_config: IcebergConfig | None, family: SparkFamily
-) -> dict[str, Any]:
-    """Resolve and merge the Iceberg config variants for the selected Spark family."""
-    if iceberg_config is None:
-        return {}
-
-    if family == SparkFamily.WHEROBOTS:
-        primary = coerce_config_dict(
-            iceberg_config.wherobots_spark_config,
-            "IcebergConfig.wherobots_spark_config",
-        )
-        s3tables = coerce_config_dict(
-            iceberg_config.wherobots_s3tables_spark_config,
-            "IcebergConfig.wherobots_s3tables_spark_config",
-        )
-    else:
-        primary = coerce_config_dict(iceberg_config.spark_config, "IcebergConfig.spark_config")
-        s3tables = coerce_config_dict(
-            iceberg_config.s3tables_spark_config,
-            "IcebergConfig.s3tables_spark_config",
-        )
-
-    return {**primary, **s3tables}
 
 
 def _build_render_setup_info(
@@ -432,7 +406,7 @@ def render_spark_job(
     family: SparkFamily = setup_info["spark_family"]
 
     # Resolve which Iceberg config variant applies for this family.
-    iceberg_spark_config = _select_iceberg_spark_config(iceberg_config, family) or None
+    iceberg_spark_config = resolve_iceberg_spark_config(iceberg_config, family) or None
 
     if family == SparkFamily.GLUE:
         package_info = _stub_package_info_glue(setup_info, pre_resolved_package_info)

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -59,6 +59,7 @@ from overture_airflow_provider.config import (
     WherobotsConfig,
     coerce_config_dict,
 )
+from overture_airflow_provider.iceberg import resolve_iceberg_spark_config
 from overture_airflow_provider.setup_info import rehydrate, to_xcom
 from overture_airflow_provider.spark_platform_handlers import get_platform_handler
 
@@ -212,41 +213,6 @@ def spark_agnostic_mapped_task_group(
 # =============================================================================
 
 
-def _select_iceberg_conf(iceberg_config: IcebergConfig | None, spark_family_name: str) -> dict:
-    """Pick the right Iceberg config variants for the resolved platform family.
-
-    Merges the primary catalog config with the S3 Tables catalog config (when
-    present) into a single dict. S3 Tables keys are namespaced under a separate
-    catalog alias so they coexist without conflicts.
-    """
-    if iceberg_config is None:
-        return {}
-
-    if spark_family_name == "WHEROBOTS":
-        primary = coerce_config_dict(
-            iceberg_config.wherobots_spark_config,
-            field_name="IcebergConfig.wherobots_spark_config",
-        )
-        s3tables = coerce_config_dict(
-            iceberg_config.wherobots_s3tables_spark_config,
-            field_name="IcebergConfig.wherobots_s3tables_spark_config",
-        )
-    else:
-        primary = coerce_config_dict(
-            iceberg_config.spark_config, field_name="IcebergConfig.spark_config"
-        )
-        s3tables = coerce_config_dict(
-            iceberg_config.s3tables_spark_config,
-            field_name="IcebergConfig.s3tables_spark_config",
-        )
-
-    if s3tables:
-        merged = dict(primary)
-        merged.update(s3tables)
-        return merged
-    return primary
-
-
 @task_group
 def _spark_agnostic_task_group(
     *,
@@ -368,7 +334,7 @@ def _spark_agnostic_task_group(
             extra_spark_env_vars=extra_spark_env_vars,
             spark_cluster_desired_worker_cores=spark_cluster_desired_worker_cores,
             spark_cluster_desired_workers=spark_cluster_desired_workers,
-            iceberg_spark_config=_select_iceberg_conf(
+            iceberg_spark_config=resolve_iceberg_spark_config(
                 iceberg_config, setup_info["spark_family_name"]
             ),
         )

--- a/src/overture_airflow_provider/spark_platform_handlers.py
+++ b/src/overture_airflow_provider/spark_platform_handlers.py
@@ -11,6 +11,7 @@ The task group calls handlers polymorphically via ``get_platform_handler``; no
 platform-specific branching lives in the orchestration layer.
 """
 
+import re
 from abc import ABC, abstractmethod
 
 from overture_airflow_provider._failures import (
@@ -125,6 +126,31 @@ def _merge_spark_conf(
     if extra_spark_conf:
         merged.update(extra_spark_conf)
     return merged
+
+
+_CATALOG_REGISTRATION_KEY = re.compile(r"spark\.sql\.catalog\.([^.]+)")
+
+
+def registered_catalog_names(spark_conf: dict) -> set[str]:
+    """Return the names of all Iceberg catalogs registered in ``spark_conf``.
+
+    A catalog is "registered" by its top-level ``spark.sql.catalog.<name>`` key
+    (the SparkCatalog class), distinct from that catalog's dotted sub-keys
+    (``...catalog-impl``, ``...warehouse``, etc.). Also includes the value of
+    ``spark.sql.defaultCatalog`` when present, in case it names a catalog that
+    for some reason lacks its own registration key.
+
+    A merged config can carry more than one registered catalog at once — e.g.
+    a primary catalog plus a coexisting S3 Tables catalog under a distinct
+    alias — so callers that need catalog-aware behavior (such as injecting
+    per-catalog credentials) must handle all of them, not just the default.
+    """
+    catalog_names = {
+        match.group(1) for key in spark_conf if (match := _CATALOG_REGISTRATION_KEY.fullmatch(key))
+    }
+    if "spark.sql.defaultCatalog" in spark_conf:
+        catalog_names.add(spark_conf["spark.sql.defaultCatalog"])
+    return catalog_names
 
 
 class SparkPlatformHandler(ABC):

--- a/tests/test_iceberg_config_templating.py
+++ b/tests/test_iceberg_config_templating.py
@@ -13,10 +13,8 @@ from unittest import mock
 
 from overture_airflow_provider._airflow_compat import DAG
 from overture_airflow_provider.config import IcebergConfig
-from overture_airflow_provider.spark_agnostic_taskgroup import (
-    _select_iceberg_conf,
-    spark_agnostic_task_group,
-)
+from overture_airflow_provider.iceberg import resolve_iceberg_spark_config
+from overture_airflow_provider.spark_agnostic_taskgroup import spark_agnostic_task_group
 
 _WAREHOUSE_TEMPLATE = (
     "arn:aws:s3tables:us-west-2:123456789012:bucket/{{ var.value.managed_bucket_iceberg }}"
@@ -105,7 +103,7 @@ def test_no_iceberg_config_defaults_to_empty():
 def test_native_render_turns_op_kwarg_into_dict():
     """On render_template_as_native_obj=True DAGs, Airflow's NativeEnvironment
     literal_evals a rendered JSON-object op_kwarg into a dict. setup_cluster_task
-    reassembles IcebergConfig from these values, so _select_iceberg_conf must
+    reassembles IcebergConfig from these values, so resolve_iceberg_spark_config must
     tolerate dicts. Regression for: json.loads(dict) -> TypeError.
     """
     s3tables = {
@@ -138,7 +136,7 @@ def test_native_render_turns_op_kwarg_into_dict():
 
     # The reassembled IcebergConfig must resolve without raising.
     cfg = IcebergConfig(spark_config=rendered)
-    result = _select_iceberg_conf(cfg, "GLUE")
+    result = resolve_iceberg_spark_config(cfg, "GLUE")
     assert result["spark.sql.catalog.s3tables_catalog.warehouse"].endswith(
         ":bucket/overture-managed-iceberg"
     )

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -13,6 +13,7 @@ from overture_airflow_provider.spark_platform_handlers import (
     GluePlatformHandler,
     WherobotsPlatformHandler,
     get_platform_handler,
+    registered_catalog_names,
 )
 
 _ICEBERG_WHEROBOTS_KEY = "spark.sql.catalog.iceberg_catalog.catalog-impl"
@@ -170,6 +171,46 @@ def _mock_iceberg_wherobots(warehouse_path):
         "spark.sql.catalog.iceberg_catalog.glue.account-id": "123456789012",
         "spark.sql.catalog.iceberg_catalog.http-client.apache.max-connections": 3000,
     }
+
+
+class TestRegisteredCatalogNames:
+    def test_no_catalogs_returns_empty_set(self):
+        assert registered_catalog_names({"spark.sql.extensions": "..."}) == set()
+
+    def test_single_registered_catalog(self):
+        conf = {
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.iceberg_catalog.warehouse": "s3://bucket/warehouse",
+        }
+        assert registered_catalog_names(conf) == {"iceberg_catalog"}
+
+    def test_registration_key_and_default_catalog_are_deduped(self):
+        conf = {
+            "spark.sql.defaultCatalog": "iceberg_catalog",
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+        }
+        assert registered_catalog_names(conf) == {"iceberg_catalog"}
+
+    def test_default_catalog_without_registration_key_still_counted(self):
+        conf = {"spark.sql.defaultCatalog": "iceberg_catalog"}
+        assert registered_catalog_names(conf) == {"iceberg_catalog"}
+
+    def test_multiple_catalogs_including_s3tables(self):
+        conf = {
+            "spark.sql.defaultCatalog": "iceberg_catalog",
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.s3tables_catalog.warehouse": "arn:aws:s3tables:...",
+        }
+        assert registered_catalog_names(conf) == {"iceberg_catalog", "s3tables_catalog"}
+
+    def test_dotted_sub_keys_are_not_mistaken_for_registrations(self):
+        conf = {
+            "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.iceberg_catalog.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+            "spark.sql.catalog.iceberg_catalog.warehouse.nested.path": "s3://bucket/warehouse",
+        }
+        assert registered_catalog_names(conf) == {"iceberg_catalog"}
 
 
 class TestGetPlatformHandler:

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -1197,6 +1197,50 @@ class TestWherobotsExecuteJob:
         spark_configs = kwargs["environment"]["sparkConfigs"]
         assert not any("client.factory" in k for k in spark_configs)
 
+    def test_s3tables_catalog_injected_without_default_catalog(self):
+        """Regression: an S3-Tables-only job (no primary catalog, so no
+        ``spark.sql.defaultCatalog``) must still get Wherobots credential
+        delegation for its catalog. Previously the injection only fired when
+        ``spark.sql.defaultCatalog`` was present, so an S3-Tables-only
+        Wherobots job silently reached the platform with an unauthenticated
+        catalog client.
+        """
+        _, kwargs = self._run(
+            extra_spark_conf={
+                "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+                "spark.sql.catalog.s3tables_catalog.catalog-impl": (
+                    "software.amazon.s3tables.iceberg.S3TablesCatalog"
+                ),
+            }
+        )
+        spark_configs = kwargs["environment"]["sparkConfigs"]
+        assert spark_configs["spark.sql.catalog.s3tables_catalog.client.factory"] == (
+            "com.wherobots.iceberg.aws.WherobotsStIntCredentialsFactory"
+        )
+        assert (
+            spark_configs["spark.sql.catalog.s3tables_catalog.client.assume-role.arn"]
+            == "arn:aws:iam::123456789012:role/wherobots-access"
+        )
+
+    def test_s3tables_and_default_catalog_both_get_credentials(self):
+        """Regression: when a primary catalog and an S3 Tables catalog
+        coexist, both must get their own Wherobots credential delegation, not
+        just the catalog named by ``spark.sql.defaultCatalog``.
+        """
+        _, kwargs = self._run(
+            extra_spark_conf={
+                "spark.sql.defaultCatalog": "iceberg_catalog",
+                "spark.sql.catalog.iceberg_catalog": "org.apache.iceberg.spark.SparkCatalog",
+                "spark.sql.catalog.s3tables_catalog": "org.apache.iceberg.spark.SparkCatalog",
+                "spark.sql.catalog.s3tables_catalog.catalog-impl": (
+                    "software.amazon.s3tables.iceberg.S3TablesCatalog"
+                ),
+            }
+        )
+        spark_configs = kwargs["environment"]["sparkConfigs"]
+        assert "spark.sql.catalog.iceberg_catalog.client.factory" in spark_configs
+        assert "spark.sql.catalog.s3tables_catalog.client.factory" in spark_configs
+
     def test_python_job_args_contain_module_and_class(self):
         _, kwargs = self._run(module_name="my_module", class_name="MyClass")
         args = kwargs["run_python"]["args"]

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-from overture_airflow_provider.config import IcebergConfig
+from overture_airflow_provider.config import IcebergConfig, WherobotsConfig
 from overture_airflow_provider.render import (
     RenderResult,
     _jsonify,
@@ -126,8 +126,11 @@ def test_render_wherobots_skips_region_resolution():
     assert isinstance(region, str)
 
 
+_WHEROBOTS_CONFIG_WITH_ROLE = WherobotsConfig(role_arn="arn:aws:iam::123456789012:role/wb-access")
+
+
 @pytest.mark.parametrize(
-    "spark_impl_name, iceberg_config, expected_primary, expected_s3tables",
+    "spark_impl_name, iceberg_config, expected_primary, expected_s3tables, wherobots_config",
     [
         (
             "GLUE_v5",
@@ -137,6 +140,7 @@ def test_render_wherobots_skips_region_resolution():
             ),
             _rest_catalog_config(),
             _s3tables_catalog_config(),
+            None,
         ),
         (
             "DATABRICKS_v15",
@@ -146,6 +150,7 @@ def test_render_wherobots_skips_region_resolution():
             ),
             _rest_catalog_config(),
             _s3tables_catalog_config(),
+            None,
         ),
         (
             "WHEROBOTS_v1_5_0",
@@ -155,15 +160,20 @@ def test_render_wherobots_skips_region_resolution():
             ),
             _wherobots_catalog_config(),
             _wherobots_s3tables_catalog_config(),
+            # Both catalogs require Wherobots credential delegation, which
+            # requires a role_arn (see test_platform_handlers.py for the
+            # dedicated coverage of that injection).
+            _WHEROBOTS_CONFIG_WITH_ROLE,
         ),
     ],
 )
 def test_render_merges_primary_and_s3tables_iceberg_configs(
-    spark_impl_name, iceberg_config, expected_primary, expected_s3tables
+    spark_impl_name, iceberg_config, expected_primary, expected_s3tables, wherobots_config
 ):
     result = render_spark_job(
         spark_impl_name=spark_impl_name,
         iceberg_config=iceberg_config,
+        wherobots_config=wherobots_config,
         **_COMMON_KWARGS,
     )
 
@@ -172,17 +182,19 @@ def test_render_merges_primary_and_s3tables_iceberg_configs(
 
 
 @pytest.mark.parametrize(
-    "spark_impl_name, iceberg_config, expected_s3tables",
+    "spark_impl_name, iceberg_config, expected_s3tables, wherobots_config",
     [
         (
             "GLUE_v5",
             IcebergConfig(s3tables_spark_config=json.dumps(_s3tables_catalog_config())),
             _s3tables_catalog_config(),
+            None,
         ),
         (
             "DATABRICKS_v15",
             IcebergConfig(s3tables_spark_config=json.dumps(_s3tables_catalog_config())),
             _s3tables_catalog_config(),
+            None,
         ),
         (
             "WHEROBOTS_v1_5_0",
@@ -190,15 +202,20 @@ def test_render_merges_primary_and_s3tables_iceberg_configs(
                 wherobots_s3tables_spark_config=json.dumps(_wherobots_s3tables_catalog_config())
             ),
             _wherobots_s3tables_catalog_config(),
+            # S3-Tables-only (no primary catalog / no spark.sql.defaultCatalog)
+            # still requires a role_arn: the S3 Tables catalog now gets
+            # Wherobots credential delegation even without a default catalog.
+            _WHEROBOTS_CONFIG_WITH_ROLE,
         ),
     ],
 )
 def test_render_preserves_s3tables_only_iceberg_configs(
-    spark_impl_name, iceberg_config, expected_s3tables
+    spark_impl_name, iceberg_config, expected_s3tables, wherobots_config
 ):
     result = render_spark_job(
         spark_impl_name=spark_impl_name,
         iceberg_config=iceberg_config,
+        wherobots_config=wherobots_config,
         **_COMMON_KWARGS,
     )
 

--- a/tests/test_select_iceberg_conf.py
+++ b/tests/test_select_iceberg_conf.py
@@ -1,11 +1,11 @@
-"""Tests for _select_iceberg_conf with S3 Tables catalog coexistence."""
+"""Tests for resolve_iceberg_spark_config with S3 Tables catalog coexistence."""
 
 import json
 
 import pytest
 
 from overture_airflow_provider.config import IcebergConfig
-from overture_airflow_provider.spark_agnostic_taskgroup import _select_iceberg_conf
+from overture_airflow_provider.iceberg import resolve_iceberg_spark_config
 
 
 def _rest_catalog_config():
@@ -41,25 +41,25 @@ def _wherobots_catalog_config():
 class TestSelectIcebergConfNone:
     @pytest.mark.parametrize("platform", ["GLUE", "DATABRICKS", "WHEROBOTS"])
     def test_returns_empty_when_config_is_none(self, platform):
-        assert _select_iceberg_conf(None, platform) == {}
+        assert resolve_iceberg_spark_config(None, platform) == {}
 
 
 class TestSelectIcebergConfPrimaryOnly:
     @pytest.mark.parametrize("platform", ["GLUE", "DATABRICKS"])
     def test_glue_databricks_returns_spark_config(self, platform):
         cfg = IcebergConfig(spark_config=json.dumps(_rest_catalog_config()))
-        assert _select_iceberg_conf(cfg, platform) == _rest_catalog_config()
+        assert resolve_iceberg_spark_config(cfg, platform) == _rest_catalog_config()
 
     def test_wherobots_returns_wherobots_spark_config(self):
         cfg = IcebergConfig(wherobots_spark_config=json.dumps(_wherobots_catalog_config()))
-        result = _select_iceberg_conf(cfg, "WHEROBOTS")
+        result = resolve_iceberg_spark_config(cfg, "WHEROBOTS")
         assert result == _wherobots_catalog_config()
 
     def test_invalid_json_identifies_field_name(self):
         cfg = IcebergConfig(spark_config="{not-json")
 
         with pytest.raises(ValueError, match=r"IcebergConfig\.spark_config"):
-            _select_iceberg_conf(cfg, "GLUE")
+            resolve_iceberg_spark_config(cfg, "GLUE")
 
     def test_non_object_json_identifies_field_name(self):
         cfg = IcebergConfig(wherobots_s3tables_spark_config='["not", "a", "dict"]')
@@ -68,30 +68,30 @@ class TestSelectIcebergConfPrimaryOnly:
             ValueError,
             match=r"IcebergConfig\.wherobots_s3tables_spark_config must decode to a JSON object",
         ):
-            _select_iceberg_conf(cfg, "WHEROBOTS")
+            resolve_iceberg_spark_config(cfg, "WHEROBOTS")
 
 
 class TestSelectIcebergConfDictInput:
     """On DAGs with render_template_as_native_obj=True, Airflow's native renderer
     literal_evals a rendered JSON-object op_kwarg back into a dict, so the
-    IcebergConfig fields arrive already parsed. _select_iceberg_conf must accept
+    IcebergConfig fields arrive already parsed. resolve_iceberg_spark_config must accept
     dicts as well as JSON strings (regression for the json.loads(dict) TypeError).
     """
 
     def test_glue_accepts_dict_spark_config(self):
         cfg = IcebergConfig(spark_config=_rest_catalog_config())
-        assert _select_iceberg_conf(cfg, "GLUE") == _rest_catalog_config()
+        assert resolve_iceberg_spark_config(cfg, "GLUE") == _rest_catalog_config()
 
     def test_wherobots_accepts_dict_spark_config(self):
         cfg = IcebergConfig(wherobots_spark_config=_wherobots_catalog_config())
-        assert _select_iceberg_conf(cfg, "WHEROBOTS") == _wherobots_catalog_config()
+        assert resolve_iceberg_spark_config(cfg, "WHEROBOTS") == _wherobots_catalog_config()
 
     def test_glue_merges_dict_primary_and_dict_s3tables(self):
         cfg = IcebergConfig(
             spark_config=_rest_catalog_config(),
             s3tables_spark_config=_s3tables_catalog_config(),
         )
-        result = _select_iceberg_conf(cfg, "GLUE")
+        result = resolve_iceberg_spark_config(cfg, "GLUE")
         assert "spark.sql.catalog.iceberg_catalog" in result
         assert "spark.sql.catalog.s3tables_catalog" in result
 
@@ -103,7 +103,7 @@ class TestSelectIcebergConfDictInput:
                 "spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections": 3000
             }
         )
-        result = _select_iceberg_conf(cfg, "GLUE")
+        result = resolve_iceberg_spark_config(cfg, "GLUE")
         assert (
             result["spark.sql.catalog.s3tables_catalog.http-client.apache.max-connections"] == 3000
         )
@@ -115,7 +115,7 @@ class TestSelectIcebergConfS3Tables:
             spark_config=json.dumps(_rest_catalog_config()),
             s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
         )
-        result = _select_iceberg_conf(cfg, "GLUE")
+        result = resolve_iceberg_spark_config(cfg, "GLUE")
         # Both catalog configs present
         assert "spark.sql.catalog.iceberg_catalog" in result
         assert "spark.sql.catalog.s3tables_catalog" in result
@@ -126,7 +126,7 @@ class TestSelectIcebergConfS3Tables:
             spark_config=json.dumps(_rest_catalog_config()),
             s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
         )
-        result = _select_iceberg_conf(cfg, "DATABRICKS")
+        result = resolve_iceberg_spark_config(cfg, "DATABRICKS")
         assert "spark.sql.catalog.iceberg_catalog" in result
         assert "spark.sql.catalog.s3tables_catalog" in result
 
@@ -139,7 +139,7 @@ class TestSelectIcebergConfS3Tables:
             wherobots_spark_config=json.dumps(_wherobots_catalog_config()),
             wherobots_s3tables_spark_config=json.dumps(wherobots_s3t),
         )
-        result = _select_iceberg_conf(cfg, "WHEROBOTS")
+        result = resolve_iceberg_spark_config(cfg, "WHEROBOTS")
         assert "spark.sql.catalog.iceberg_catalog" in result
         assert "spark.sql.catalog.s3tables_catalog" in result
 
@@ -147,7 +147,7 @@ class TestSelectIcebergConfS3Tables:
         cfg = IcebergConfig(
             s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
         )
-        result = _select_iceberg_conf(cfg, "GLUE")
+        result = resolve_iceberg_spark_config(cfg, "GLUE")
         assert "spark.sql.catalog.s3tables_catalog" in result
         assert "spark.sql.catalog.iceberg_catalog" not in result
 
@@ -156,7 +156,7 @@ class TestSelectIcebergConfS3Tables:
             spark_config=json.dumps(_rest_catalog_config()),
             s3tables_spark_config="{}",
         )
-        result = _select_iceberg_conf(cfg, "GLUE")
+        result = resolve_iceberg_spark_config(cfg, "GLUE")
         assert result == _rest_catalog_config()
 
     def test_extra_spark_conf_still_wins_downstream(self):
@@ -166,6 +166,6 @@ class TestSelectIcebergConfS3Tables:
             spark_config=json.dumps(_rest_catalog_config()),
             s3tables_spark_config=json.dumps(_s3tables_catalog_config()),
         )
-        result = _select_iceberg_conf(cfg, "GLUE")
+        result = resolve_iceberg_spark_config(cfg, "GLUE")
         # S3 Tables values are present as-is before extra_spark_conf is applied
         assert result["spark.sql.catalog.s3tables_catalog.rest.signing-region"] == "us-west-2"


### PR DESCRIPTION
## Root cause

`build_wherobots_operator_kwargs` (`_wherobots.py`) only injected the Wherobots credential factory (`client.factory` / `client.assume-role.*` / `client.credentials-provider*`) for the catalog named by `spark.sql.defaultCatalog`.

`_select_iceberg_conf` / `_select_iceberg_spark_config` correctly merge `wherobots_spark_config` (primary) with `wherobots_s3tables_spark_config` (S3 Tables), so the S3 Tables catalog's raw keys (`spark.sql.catalog.s3tables_catalog.*`) *do* reach `merged_spark_conf` and the final job. But the credential-delegation step — added before S3 Tables support existed and never revisited in #10 — only fires for one catalog name (the default one). So:

- With both a primary + S3 Tables catalog, only the primary gets Wherobots assume-role credentials; the S3 Tables catalog gets none.
- With an S3-Tables-only job (no primary catalog, so no `spark.sql.defaultCatalog`), the check never fires at all — **no catalog gets credentials, silently**.

Either way, the Wherobots-managed pod has no way to assume the customer's role for the S3 Tables catalog, so catalog access fails at runtime even though the config keys are technically present — matching the reported symptom ("S3 Tables spark config isn't making it to the final job").

## Fix

`build_wherobots_operator_kwargs` now scans for every registered catalog (`spark.sql.catalog.<name>` keys, plus `spark.sql.defaultCatalog` for back-compat) and injects the Wherobots credential delegation block for each one, instead of only the default catalog. `WherobotsConfig.role_arn` is still required whenever any catalog is registered (previously this validation could be silently skipped for S3-Tables-only jobs).

Updated `SPEC.md`'s Wherobots section to describe the corrected behavior.

## Tests

Added regression coverage in `tests/test_platform_handlers.py`:
- S3-Tables-only Wherobots job (no default catalog) gets credential delegation for its catalog.
- Primary + S3 Tables coexistence: both catalogs get their own credential delegation.

Updated the WHEROBOTS parametrize cases in `tests/test_render.py` to supply `WherobotsConfig(role_arn=...)`, since those fixtures previously happened to dodge the (buggy) credential check by omitting `spark.sql.defaultCatalog`.

All 475 tests pass (`uv run pytest -v`, `uv run ruff check .`, `uv run ruff format --check .`).

## Follow-up

While re-investigating a later prod recurrence of this symptom, found a *second*, distinct root cause that is **not** in this repo: the client-side `tf-data-platform` wrapper (`spark_factory.py`) never populates `wherobots_s3tables_spark_config` at all, so the S3 Tables catalog is never registered for Wherobots jobs in the first place (this fix here only ensures credentials are injected for whatever catalogs *are* registered). Tracked separately in #59 and OvertureMaps/tf-data-platform#4336, with a fix in progress on the `tf-data-platform` side.
