### PR TITLE
[FEATURE] Raise AirflowFailException when a submitted Spark run fails, so callers can safely retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-05
+
+### Changed
+
+- **`execute_spark_job` failures now raise `AirflowFailException` when the job
+  actually launched, instead of a plain `AirflowException` in every case.**
+  `describe_failure` already classifies failures by whether the run reached
+  the platform (`run_launched`); this now drives the exception type too:
+  `submit/config` failures (never launched) stay retryable, while
+  `downstream-job` and `trigger/polling` failures (launched, then failed, or a
+  Triggerer crash after launch) raise the non-retryable
+  `AirflowFailException`. Callers can set `retries=1` (or higher) on
+  `execute_spark_job` and get automatic recovery from transient
+  submission-time infra faults, without risking a silent retry of a job that
+  actually ran and failed.
+  ([#65](https://github.com/OvertureMaps/overture-airflow-provider/issues/65))
+
 ## [0.3.1] - 2026-06-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The provider is intentionally unopinionated: every environment-specific value (S
 - [Operator links](#operator-links)
 - [Failure messages](#failure-messages)
   - [Retries](#retries)
+    - [What's retryable](#whats-retryable)
+    - [What isn't](#what-isnt)
 - [Databricks runner deployment](#databricks-runner-deployment)
 - [Local rendering](#local-rendering)
 - [Reference](#reference)
@@ -141,10 +143,17 @@ The hint layer scans the reason and root-cause text for known patterns (IAM deni
 
 ### Retries
 
-`execute_spark_job` defaults to `retries=0`: a job that fails costs real compute to re-run, so this provider doesn't retry by default. Raising `retries` is safe, though, because the exception type follows whether the job actually reached the platform:
+`execute_spark_job` defaults to `retries=0`: a job that fails costs real compute to re-run, so this provider doesn't retry by default.
 
-- `downstream-job` and `trigger/polling` failures (the run launched, then failed, or a Triggerer crash happened mid-poll) raise `AirflowFailException`, which Airflow never retries regardless of the task's `retries=`.
-- `submit/config` failures (the run never reached the platform, e.g. a worker recycling mid-submit) raise the retryable `AirflowException`.
+Every failure classification above already carries a `run_launched` signal, whether the job reached the platform before it failed. Raising `retries` is a small, safe adjustment on top of that existing signal: the exception type just follows it.
+
+#### What's retryable
+
+`submit/config` failures raise the retryable `AirflowException`. The run never reached the platform (a worker recycling mid-submit, a bad cluster policy), so nothing ran and nothing costs money to redo.
+
+#### What isn't
+
+`downstream-job` and `trigger/polling` failures raise `AirflowFailException`, which Airflow never retries regardless of the task's `retries=`. The run launched, then failed, or a Triggerer crash happened mid-poll after launch, so re-running it blindly burns another full job at cost instead of fixing anything.
 
 Set `retries=1` (or higher) on `execute_spark_job` to recover automatically from transient submission-time infra faults without risking a silent, full-cost retry of a job that actually ran and failed.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The provider is intentionally unopinionated: every environment-specific value (S
 - [Quick start](#quick-start)
 - [Operator links](#operator-links)
 - [Failure messages](#failure-messages)
+  - [Retries](#retries)
 - [Databricks runner deployment](#databricks-runner-deployment)
 - [Local rendering](#local-rendering)
 - [Reference](#reference)
@@ -137,6 +138,15 @@ Spark job FAILED on GLUE (downstream job error, not a provider/submit fault).
 Classifications: `downstream-job`, `submit/config`, `trigger/polling`, `platform/infra`.
 
 The hint layer scans the reason and root-cause text for known patterns (IAM denials, auth errors, OOM, throttling, missing resources) and appends an actionable message automatically.
+
+### Retries
+
+`execute_spark_job` defaults to `retries=0`: a job that fails costs real compute to re-run, so this provider doesn't retry by default. Raising `retries` is safe, though, because the exception type follows whether the job actually reached the platform:
+
+- `downstream-job` and `trigger/polling` failures (the run launched, then failed, or a Triggerer crash happened mid-poll) raise `AirflowFailException`, which Airflow never retries regardless of the task's `retries=`.
+- `submit/config` failures (the run never reached the platform, e.g. a worker recycling mid-submit) raise the retryable `AirflowException`.
+
+Set `retries=1` (or higher) on `execute_spark_job` to recover automatically from transient submission-time infra faults without risking a silent, full-cost retry of a job that actually ran and failed.
 
 ## Databricks runner deployment
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -189,7 +189,17 @@ on signals the orchestration layer already holds:
 `apply_heuristics()` scans the combined reason + root-cause text for known
 patterns (IAM denials, auth errors, OOM, throttling, missing resources) and
 appends an actionable hint. `format_failure()` renders all fields into a
-uniform multi-line `AirflowException` message.
+uniform multi-line message.
+
+`_operator.py` picks the raised exception type from the same `run_launched`
+signal that drives classification above: `downstream-job` and `trigger/polling`
+(the run reached the platform, or a Triggerer crash happened mid-poll after
+launch) raise `AirflowFailException`, which Airflow never retries regardless of
+the task's `retries=`. `submit/config` (the run never reached the platform)
+raises the retryable `AirflowException`. This lets a caller set
+`retries=1` on `execute_spark_job` to recover from transient submission-time
+infra faults (e.g. a worker recycling mid-submit) without risking a silent
+retry of a job that actually ran and failed.
 
 `_failures.py` has no Airflow or platform SDK imports; it works purely from
 stdlib so it is testable and importable without any runtime dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.5.1"
+version = "0.6.0"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_airflow_compat.py
+++ b/src/overture_airflow_provider/_airflow_compat.py
@@ -12,7 +12,8 @@ Symbol                Airflow 2.x                                    Airflow 3.x
 ``BaseHook``          ``airflow.hooks.base.BaseHook``                ``airflow.sdk.bases.hook.BaseHook``
 ``BaseOperatorLink``  ``airflow.models.baseoperatorlink``            ``airflow.sdk.bases.operator.BaseOperatorLink``
 ``XCom``              ``airflow.models.xcom.XCom``                   ``airflow.sdk.execution_time.xcom.XCom``
-``AirflowException``  ``airflow.exceptions.AirflowException``        (both)
+``AirflowException``      ``airflow.exceptions.AirflowException``        (same)
+``AirflowFailException``  ``airflow.exceptions.AirflowFailException``    ``airflow.sdk.exceptions.AirflowFailException``
 ====================  =============================================  =============================================
 
 Callers should always import from this module, never directly from
@@ -26,14 +27,14 @@ try:  # Airflow 3.x
     from airflow.sdk import DAG, BaseOperator, task, task_group
     from airflow.sdk.bases.hook import BaseHook
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
-    from airflow.sdk.exceptions import TaskDeferred
+    from airflow.sdk.exceptions import AirflowFailException, TaskDeferred
     from airflow.sdk.execution_time.xcom import XCom
 
     AIRFLOW_MAJOR = 3
 except ImportError:  # Airflow 2.x
     from airflow import DAG
     from airflow.decorators import task, task_group
-    from airflow.exceptions import TaskDeferred
+    from airflow.exceptions import AirflowFailException, TaskDeferred
     from airflow.hooks.base import BaseHook
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.baseoperatorlink import BaseOperatorLink
@@ -45,6 +46,7 @@ __all__ = [
     "AIRFLOW_MAJOR",
     "DAG",
     "AirflowException",
+    "AirflowFailException",
     "BaseHook",
     "BaseOperator",
     "BaseOperatorLink",

--- a/src/overture_airflow_provider/_operator.py
+++ b/src/overture_airflow_provider/_operator.py
@@ -25,6 +25,7 @@ import json
 
 from overture_airflow_provider._airflow_compat import (
     AirflowException,
+    AirflowFailException,
     BaseOperator,
     TaskDeferred,
 )
@@ -147,11 +148,17 @@ class SparkAgnosticExecuteOperator(BaseOperator):
             # A failure on the submit/synchronous path. Whether the job actually
             # launched (early run-id XCom present) decides downstream-job vs
             # submit/config; describe_failure + the classifier handle the rest.
+            run_launched = self._run_launched(context)
             info = handler.describe_failure(
                 error=exc,
-                run_launched=self._run_launched(context),
+                run_launched=run_launched,
             )
-            raise AirflowException(format_failure(info)) from None
+            # Launched-and-failed is a real job/data bug -- retrying just burns
+            # another full run at cost, so it's never retryable. Never-launched
+            # is a submit/config fault (e.g. a worker recycle mid-submit) that a
+            # caller-configured retry can safely resolve.
+            exc_cls = AirflowFailException if run_launched else AirflowException
+            raise exc_cls(format_failure(info)) from None
 
         trigger = submitted.get("trigger")
         if trigger is None:
@@ -182,8 +189,12 @@ class SparkAgnosticExecuteOperator(BaseOperator):
         and 3) and route the error through the same per-platform
         ``describe_failure`` seam used by the submit and complete paths, tagged
         ``is_trigger_failure`` so the classifier buckets it as ``trigger/polling``.
-        Every other resume (a normal trigger event) is delegated untouched to the
-        base implementation, which dispatches to ``execute_complete``.
+        A trigger only exists once a job has launched, so this path is always
+        ``run_launched=True`` and raises the non-retryable
+        ``AirflowFailException`` -- a Triggerer crash mid-poll doesn't mean the
+        job is safe to resubmit. Every other resume (a normal trigger event) is
+        delegated untouched to the base implementation, which dispatches to
+        ``execute_complete``.
         """
         if next_method == "__fail__":
             next_kwargs = next_kwargs or {}
@@ -198,7 +209,7 @@ class SparkAgnosticExecuteOperator(BaseOperator):
                 run_launched=True,
                 is_trigger_failure=True,
             )
-            raise AirflowException(format_failure(info)) from None
+            raise AirflowFailException(format_failure(info)) from None
         return super().resume_execution(next_method, next_kwargs, context)
 
     def _push_report_issue_config(self, context) -> None:

--- a/src/overture_airflow_provider/spark_agnostic_taskgroup.py
+++ b/src/overture_airflow_provider/spark_agnostic_taskgroup.py
@@ -119,8 +119,12 @@ def spark_agnostic_task_group(
         parameters: Job parameters as a JSON string passed to the entry point.
         pool: Airflow pool for the ``execute_spark_job`` task.
         retries: Retry count for the ``execute_spark_job`` task (default 0).
-            The setup tasks (``setup``, ``download_python_packages``,
-            ``download_jars``, ``setup_cluster``) always retry twice.
+            Safe to raise: a failure that never reached the platform (submit
+            or config fault) raises a retryable ``AirflowException``, while a
+            failure after the job launched raises ``AirflowFailException``,
+            which Airflow never retries regardless of this setting. The setup
+            tasks (``setup``, ``download_python_packages``, ``download_jars``,
+            ``setup_cluster``) always retry twice.
         iceberg_config: Iceberg Spark config for both Glue/Databricks and
             Wherobots; the right variant is selected at runtime. Pass ``None``
             for jobs that don't use Iceberg.

--- a/tests/test_spark_agnostic_operator.py
+++ b/tests/test_spark_agnostic_operator.py
@@ -112,10 +112,13 @@ def test_execute_wraps_submit_failure_with_classified_message():
     assert "submit/config failure" in msg
     assert "hint:" in msg
     assert handler.describe_failure.call_args.kwargs["run_launched"] is False
+    # Never-launched failures are retryable: exactly AirflowException, not the
+    # non-retryable AirflowFailException subclass.
+    assert type(exc.value) is AirflowException
 
 
 def test_execute_submit_failure_marks_downstream_when_launched():
-    from overture_airflow_provider._airflow_compat import AirflowException
+    from overture_airflow_provider._airflow_compat import AirflowFailException
     from overture_airflow_provider._failures import DOWNSTREAM_JOB, FailureInfo
 
     op = _make_operator()
@@ -138,14 +141,16 @@ def test_execute_submit_failure_marks_downstream_when_launched():
             return_value=handler,
         ),
     ):
-        with pytest.raises(AirflowException):
+        # Launched-and-failed is never retryable, regardless of the caller's
+        # `retries=` setting.
+        with pytest.raises(AirflowFailException):
             op.execute(context)
 
     assert handler.describe_failure.call_args.kwargs["run_launched"] is True
 
 
 def test_resume_execution_enriches_trigger_failure():
-    from overture_airflow_provider._airflow_compat import AirflowException
+    from overture_airflow_provider._airflow_compat import AirflowFailException
     from overture_airflow_provider._failures import TRIGGER_POLLING, FailureInfo
 
     op = _make_operator()
@@ -165,7 +170,9 @@ def test_resume_execution_enriches_trigger_failure():
             return_value=handler,
         ),
     ):
-        with pytest.raises(AirflowException) as exc:
+        # A trigger crash mid-poll means the job did launch, so this is never
+        # retryable regardless of the caller's `retries=` setting.
+        with pytest.raises(AirflowFailException) as exc:
             op.resume_execution(
                 "__fail__",
                 {"error": "Triggerer lost connection", "traceback": ["line1", "line2"]},


### PR DESCRIPTION
### Root cause

`execute_spark_job` (`SparkAgnosticExecuteOperator`) has `retries=0` by design; callers opt in. But `execute()`'s failure path raised a plain `AirflowException` regardless of whether the job actually reached the platform, so any caller that set `retries` would blindly re-run genuinely broken jobs at full compute cost, not just transient submission faults.

`tf-data-platform` hit this in prod ([OvertureMaps/tf-data-platform#4698](https://github.com/OvertureMaps/tf-data-platform/issues/4698)): a Celery worker died before the Glue submit call ran, no CloudWatch log stream was ever created, and no task-level exception fired ([apache/airflow#42991](https://github.com/apache/airflow/discussions/42991)'s executor/scheduler race, landing on a worker crash instead of the benign timing lag [apache/airflow#43063](https://github.com/apache/airflow/pull/43063) fixed for 2.10.4+). The task sat failed for 10 hours needing a manual clear, because `retries` wasn't safe to set.

### Fix

Now the exception type follows the `run_launched` signal `describe_failure` already computes: `run_launched=False` (submit/config fault, safe to retry) raises `AirflowException`; `run_launched=True` (job launched and failed, or a Triggerer crash mid-poll in `resume_execution`'s `__fail__` handling) raises `AirflowFailException`, which Airflow never retries regardless of the task's `retries=`. Fixes #65.

Added `AirflowFailException` to `_airflow_compat.py`: same import path on Airflow 2.x (`airflow.exceptions`), but Airflow 3.x needs `airflow.sdk.exceptions` to avoid a deprecation warning.

## Testing

`uv run ruff check .` and `uv run ruff format --check .` pass. `uv run pytest -q` passes 318 tests; the operator/handler test files (including the updated ones for this change) can't collect in this Windows dev venv because `apache-airflow-task-sdk` 1.3.0 fails to import (`os.register_at_fork` doesn't exist on Windows) -- confirmed via `git stash` that this breaks identically on `main`, unrelated to this change.