### PR TITLE
[FEATURE] Add bundle_inspector plugin for browsing Overture bundles in S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-06
+
+### Added
+
+- **`bundle_inspector` plugin, ported from `tf-data-platform`.** Adds a
+  Browse -> Bundle Inspector UI for walking pipeline stages, themes, schema
+  versions, and run IDs in S3, plus GeoParquet/PMTiles preview and ad hoc
+  Athena queries against the same bundle. Loads on both Airflow 2 (Flask
+  blueprints) and Airflow 3 (FastAPI apps), selected automatically at import
+  time. Configure it via the `[bundle_inspector]` section in `airflow.cfg`
+  (`s3_bucket`, `environment`, `athena_output_bucket`, `user`), each also
+  settable through its `AIRFLOW__BUNDLE_INSPECTOR__<OPTION>` environment
+  variable. GeoParquet preview needs the new `bundle-inspector` extra
+  (`pyarrow`, `shapely`). The original's `/register-table` endpoint isn't
+  ported: it depended on `tf-data-platform`-internal DAG naming with no
+  equivalent here.
+  ([#68](https://github.com/OvertureMaps/overture-airflow-provider/issues/68))
+
 ## [0.6.0] - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -230,14 +230,16 @@ Pass `pre_resolved_package_info=` or `pre_resolved_jar_info=` with real S3 URIs 
 
 Installing this package registers `bundle_inspector`, an Airflow plugin (not related to `spark_agnostic_task_group`) for browsing Overture bundles in S3 by pipeline stage, theme, schema version, and run ID. It works on both Airflow 2 (Flask blueprints) and Airflow 3 (FastAPI apps); the right one loads automatically. No plugins-folder drop-in needed, no separate install step: it ships in this package and shows up under **Browse -> Bundle Inspector** once the provider is installed.
 
-Configure it with these Airflow Variables:
+Configure it via the `[bundle_inspector]` section in `airflow.cfg`:
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `bundle_inspector_s3_bucket` | yes | S3 bucket containing bundle data |
-| `bundle_inspector_environment` | no (default `dev`) | Environment name (`dev`, `staging`, `prod`) |
-| `bundle_inspector_athena_output_bucket` | no | S3 bucket for Athena query results; falls back to `overture-bundle-inspector-athena-output-<environment>` |
-| `bundle_inspector_user` | no | Namespace prefix under the bucket, read only when `bundle_inspector_environment` is `dev` |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `s3_bucket` | yes | S3 bucket containing bundle data |
+| `environment` | no (default `dev`) | Environment name (`dev`, `staging`, `prod`) |
+| `athena_output_bucket` | no | S3 bucket for Athena query results; falls back to `overture-bundle-inspector-athena-output-<environment>` |
+| `user` | no | Namespace prefix under the bucket, read only when `environment` is `dev` |
+
+Each option is also settable via its `AIRFLOW__BUNDLE_INSPECTOR__<OPTION>` environment variable (e.g. `AIRFLOW__BUNDLE_INSPECTOR__S3_BUCKET`), Airflow's standard override convention for provider config, so no metadata DB round-trip or Variable setup is needed to get the plugin running.
 
 GeoParquet preview (`component-data`, `parquet-stats`) needs `pyarrow` and `shapely`: `pip install "airflow-provider-overture[bundle-inspector]"`. Without them those two endpoints return a 500 with the import error; the rest of the UI (tree browsing, PMTiles, CSV, Athena queries) works without either.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The provider is intentionally unopinionated: every environment-specific value (S
     - [What isn't](#what-isnt)
 - [Databricks runner deployment](#databricks-runner-deployment)
 - [Local rendering](#local-rendering)
+- [Bundle Inspector plugin](#bundle-inspector-plugin)
 - [Reference](#reference)
   - [Supported versions](#supported-versions)
   - [Spark platform matrix](#spark-platform-matrix)
@@ -224,6 +225,21 @@ result.write_to("./out/")  # dump JSON payloads + cli.sh
 ```
 
 Pass `pre_resolved_package_info=` or `pre_resolved_jar_info=` with real S3 URIs from a previous `download_python_packages_*` or `download_jars_*` run to skip the `s3://.../REPLACE-ME.whl` placeholders.
+
+## Bundle Inspector plugin
+
+Installing this package registers `bundle_inspector`, an Airflow plugin (not related to `spark_agnostic_task_group`) for browsing Overture bundles in S3 by pipeline stage, theme, schema version, and run ID. It works on both Airflow 2 (Flask blueprints) and Airflow 3 (FastAPI apps); the right one loads automatically. No plugins-folder drop-in needed, no separate install step: it ships in this package and shows up under **Browse -> Bundle Inspector** once the provider is installed.
+
+Configure it with these Airflow Variables:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `bundle_inspector_s3_bucket` | yes | S3 bucket containing bundle data |
+| `bundle_inspector_environment` | no (default `dev`) | Environment name (`dev`, `staging`, `prod`) |
+| `bundle_inspector_athena_output_bucket` | no | S3 bucket for Athena query results; falls back to `overture-bundle-inspector-athena-output-<environment>` |
+| `bundle_inspector_user` | no | Namespace prefix under the bucket, read only when `bundle_inspector_environment` is `dev` |
+
+GeoParquet preview (`component-data`, `parquet-stats`) needs `pyarrow` and `shapely`: `pip install "airflow-provider-overture[bundle-inspector]"`. Without them those two endpoints return a 500 with the import error; the rest of the UI (tree browsing, PMTiles, CSV, Athena queries) works without either.
 
 ## Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,13 @@ Issues = "https://github.com/OvertureMaps/overture-airflow-provider/issues"
 [project.entry-points."apache_airflow_provider"]
 airflow-provider-overture = "overture_airflow_provider.provider_info:get_provider_info"
 
+# `provider_info.py`'s "plugins" key alone only loads the plugin when
+# `core.lazy_discover_providers=False`, which isn't the default. A classic
+# `airflow.plugins` entry point (how apache-airflow-providers-openlineage
+# does it) loads unconditionally.
+[project.entry-points."airflow.plugins"]
+bundle_inspector = "overture_airflow_provider.plugins.bundle_inspector:BundleInspectorPlugin"
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,13 @@ dependencies = [
 [project.optional-dependencies]
 databricks = ["apache-airflow-providers-databricks", "databricks-sdk"]
 wherobots = ["airflow-providers-wherobots"]
+bundle-inspector = ["pyarrow", "shapely"]
 all = [
     "apache-airflow-providers-databricks",
     "databricks-sdk",
     "airflow-providers-wherobots",
+    "pyarrow",
+    "shapely",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.6.0"
+version = "0.7.0"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_airflow_compat.py
+++ b/src/overture_airflow_provider/_airflow_compat.py
@@ -12,7 +12,6 @@ Symbol                Airflow 2.x                                    Airflow 3.x
 ``BaseHook``          ``airflow.hooks.base.BaseHook``                ``airflow.sdk.bases.hook.BaseHook``
 ``BaseOperatorLink``  ``airflow.models.baseoperatorlink``            ``airflow.sdk.bases.operator.BaseOperatorLink``
 ``XCom``              ``airflow.models.xcom.XCom``                   ``airflow.sdk.execution_time.xcom.XCom``
-``Variable``          ``airflow.models.Variable``                    ``airflow.sdk.Variable``
 ``AirflowException``      ``airflow.exceptions.AirflowException``        (same)
 ``AirflowFailException``  ``airflow.exceptions.AirflowFailException``    ``airflow.sdk.exceptions.AirflowFailException``
 ====================  =============================================  =============================================
@@ -25,7 +24,7 @@ module to the ``airflow.sdk`` branch (or just inline the imports).
 from airflow.exceptions import AirflowException
 
 try:  # Airflow 3.x
-    from airflow.sdk import DAG, BaseOperator, Variable, task, task_group
+    from airflow.sdk import DAG, BaseOperator, task, task_group
     from airflow.sdk.bases.hook import BaseHook
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.exceptions import AirflowFailException, TaskDeferred
@@ -39,7 +38,6 @@ except ImportError:  # Airflow 2.x
     from airflow.hooks.base import BaseHook
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.baseoperatorlink import BaseOperatorLink
-    from airflow.models.variable import Variable
     from airflow.models.xcom import XCom
 
     AIRFLOW_MAJOR = 2
@@ -53,7 +51,6 @@ __all__ = [
     "BaseOperator",
     "BaseOperatorLink",
     "TaskDeferred",
-    "Variable",
     "XCom",
     "task",
     "task_group",

--- a/src/overture_airflow_provider/_airflow_compat.py
+++ b/src/overture_airflow_provider/_airflow_compat.py
@@ -12,6 +12,7 @@ Symbol                Airflow 2.x                                    Airflow 3.x
 ``BaseHook``          ``airflow.hooks.base.BaseHook``                ``airflow.sdk.bases.hook.BaseHook``
 ``BaseOperatorLink``  ``airflow.models.baseoperatorlink``            ``airflow.sdk.bases.operator.BaseOperatorLink``
 ``XCom``              ``airflow.models.xcom.XCom``                   ``airflow.sdk.execution_time.xcom.XCom``
+``Variable``          ``airflow.models.Variable``                    ``airflow.sdk.Variable``
 ``AirflowException``      ``airflow.exceptions.AirflowException``        (same)
 ``AirflowFailException``  ``airflow.exceptions.AirflowFailException``    ``airflow.sdk.exceptions.AirflowFailException``
 ====================  =============================================  =============================================
@@ -24,7 +25,7 @@ module to the ``airflow.sdk`` branch (or just inline the imports).
 from airflow.exceptions import AirflowException
 
 try:  # Airflow 3.x
-    from airflow.sdk import DAG, BaseOperator, task, task_group
+    from airflow.sdk import DAG, BaseOperator, Variable, task, task_group
     from airflow.sdk.bases.hook import BaseHook
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.exceptions import AirflowFailException, TaskDeferred
@@ -38,6 +39,7 @@ except ImportError:  # Airflow 2.x
     from airflow.hooks.base import BaseHook
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.baseoperatorlink import BaseOperatorLink
+    from airflow.models.variable import Variable
     from airflow.models.xcom import XCom
 
     AIRFLOW_MAJOR = 2
@@ -51,6 +53,7 @@ __all__ = [
     "BaseOperator",
     "BaseOperatorLink",
     "TaskDeferred",
+    "Variable",
     "XCom",
     "task",
     "task_group",

--- a/src/overture_airflow_provider/plugins/__init__.py
+++ b/src/overture_airflow_provider/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Airflow plugins bundled with this provider.
+
+Each subpackage here is a self-contained ``AirflowPlugin`` registered via
+``get_provider_info()``'s ``plugins`` key (see ``provider_info.py``), so it
+loads automatically wherever this provider package is installed.
+"""

--- a/src/overture_airflow_provider/plugins/bundle_inspector/__init__.py
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/__init__.py
@@ -1,0 +1,88 @@
+"""Bundle Inspector plugin for Apache Airflow.
+
+Provides a UI for browsing Overture Maps bundles in S3, organized by
+pipeline stage, theme, schema version, and run ID. Registered via
+``get_provider_info()``'s ``plugins`` entry (see ``provider_info.py``), so it
+loads automatically wherever this package is installed -- no separate
+plugins-folder drop-in required.
+
+Supports both Airflow 2 (Flask Blueprints + FAB menu items) and Airflow 3
+(FastAPI apps + External Views), selected at import time via
+``overture_airflow_provider._airflow_compat.AIRFLOW_MAJOR``. Each framework's
+adapter module (``flask_app.py`` / ``fastapi_app.py``) is only imported on
+the major version that ships that framework, so neither becomes a hard
+dependency of the other.
+"""
+
+import logging
+
+from airflow.plugins_manager import AirflowPlugin
+
+from overture_airflow_provider._airflow_compat import AIRFLOW_MAJOR
+
+logger = logging.getLogger(__name__)
+
+_flask_blueprints: list = []
+_appbuilder_menu_items: list = []
+_fastapi_apps: list = []
+_external_views: list = []
+
+if AIRFLOW_MAJOR == 2:
+    try:
+        from .flask_app import bundle_inspector_api_bp, bundle_inspector_bp
+
+        _flask_blueprints = [bundle_inspector_bp, bundle_inspector_api_bp]
+        _appbuilder_menu_items = [
+            {
+                "name": "Bundle Inspector",
+                "href": "/bundle-inspector/",
+                "category": "Browse",
+            }
+        ]
+    except ImportError:
+        logger.warning(
+            "Bundle Inspector plugin disabled: Flask is not installed. "
+            "Install the Airflow 2 webserver extras to enable it.",
+        )
+else:
+    try:
+        from .fastapi_app import build_api_app, build_ui_app
+
+        _fastapi_apps = [
+            {
+                "app": build_ui_app(),
+                "url_prefix": "/bundle-inspector",
+                "name": "Bundle Inspector UI",
+            },
+            {
+                "app": build_api_app(),
+                "url_prefix": "/api/bundle-inspector",
+                "name": "Bundle Inspector API",
+            },
+        ]
+        _external_views = [
+            {
+                "name": "Bundle Inspector",
+                "href": "/bundle-inspector/",
+                "destination": "nav",
+                "category": "Browse",
+                "url_route": "bundle-inspector",
+            }
+        ]
+    except Exception:
+        logger.warning(
+            "Bundle Inspector plugin disabled: could not build its FastAPI apps "
+            "(FastAPI or Airflow's FastAPI auth dependency unavailable).",
+            exc_info=True,
+        )
+
+
+class BundleInspectorPlugin(AirflowPlugin):
+    """Airflow plugin for bundle inspection."""
+
+    name = "bundle_inspector"
+    flask_blueprints = _flask_blueprints
+    appbuilder_views: list = []
+    appbuilder_menu_items = _appbuilder_menu_items
+    fastapi_apps = _fastapi_apps
+    external_views = _external_views

--- a/src/overture_airflow_provider/plugins/bundle_inspector/_endpoints.py
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/_endpoints.py
@@ -12,16 +12,17 @@ import os
 import re
 from functools import lru_cache
 
-from overture_airflow_provider._airflow_compat import Variable
+from airflow.configuration import conf
 
 from . import s3
 
-# Airflow Variable names. Override any of them per-deployment; none are
-# baked into the plugin beyond these key names.
-S3_BUCKET_VARIABLE = "bundle_inspector_s3_bucket"
-ATHENA_OUTPUT_BUCKET_VARIABLE = "bundle_inspector_athena_output_bucket"
-ENVIRONMENT_VARIABLE = "bundle_inspector_environment"
-USER_VARIABLE = "bundle_inspector_user"
+# ``airflow.cfg`` section for this plugin's settings (see provider_info.py's
+# "config" entry for the full option list). Airflow merges this section's
+# defaults/descriptions from that entry, so `conf.get` works even before an
+# operator has set anything explicitly, and every option is overridable via
+# the standard `AIRFLOW__BUNDLE_INSPECTOR__<OPTION>` env var without any
+# extra wiring here.
+CONFIG_SECTION = "bundle_inspector"
 
 QUERY_ID_PATTERN = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -58,25 +59,30 @@ def _s3_client():
 
 
 def get_config(user_override: str | None = None) -> dict:
-    """Read bucket and namespace config from Airflow Variables.
+    """Read bucket and namespace config from ``airflow.cfg``'s ``bundle_inspector`` section.
 
-    Called inside request handlers, never at import time, to avoid hitting
-    the metadata DB during plugin loading.
+    Called inside request handlers, never at import time, so a config change
+    (or its `AIRFLOW__BUNDLE_INSPECTOR__*` env var override) takes effect
+    without restarting the plugin.
 
-    The environment is read from the ``bundle_inspector_environment``
-    Airflow Variable so the namespace decision uses the same source of
-    truth. In ``dev``, the namespace is taken from the
-    ``bundle_inspector_user`` Airflow Variable (or overridden by
-    ``user_override``).
+    The environment is read from the ``environment`` option so the namespace
+    decision uses the same source of truth. In ``dev``, the namespace is
+    taken from the ``user`` option (or overridden by ``user_override``).
     """
-    bucket = Variable.get(S3_BUCKET_VARIABLE)
-    athena_output_bucket = Variable.get(ATHENA_OUTPUT_BUCKET_VARIABLE, default_var=None)
-    environment = Variable.get(ENVIRONMENT_VARIABLE, default_var="dev")
+    bucket = conf.get(CONFIG_SECTION, "s3_bucket", fallback=None)
+    if not bucket:
+        raise ApiError(
+            500,
+            f"[{CONFIG_SECTION}] s3_bucket is not set in airflow.cfg "
+            f"(or AIRFLOW__{CONFIG_SECTION.upper()}__S3_BUCKET)",
+        )
+    athena_output_bucket = conf.get(CONFIG_SECTION, "athena_output_bucket", fallback=None)
+    environment = conf.get(CONFIG_SECTION, "environment", fallback="dev")
     if environment == "dev":
         namespace = (
             user_override
             if user_override is not None
-            else Variable.get(USER_VARIABLE, default_var="")
+            else conf.get(CONFIG_SECTION, "user", fallback="")
         )
     else:
         namespace = ""

--- a/src/overture_airflow_provider/plugins/bundle_inspector/_endpoints.py
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/_endpoints.py
@@ -1,0 +1,466 @@
+"""Framework-agnostic request handling for the bundle inspector API.
+
+These functions contain the actual routing logic (config resolution, param
+parsing, calls into :mod:`s3`) with no Flask or FastAPI imports. Airflow 2
+loads Flask blueprints; Airflow 3 loads FastAPI apps; each framework adapter
+(``flask_app.py`` / ``fastapi_app.py``) is a thin wrapper over this module so
+neither web framework becomes a hard import for the Airflow major version
+that doesn't ship it.
+"""
+
+import os
+import re
+from functools import lru_cache
+
+from overture_airflow_provider._airflow_compat import Variable
+
+from . import s3
+
+# Airflow Variable names. Override any of them per-deployment; none are
+# baked into the plugin beyond these key names.
+S3_BUCKET_VARIABLE = "bundle_inspector_s3_bucket"
+ATHENA_OUTPUT_BUCKET_VARIABLE = "bundle_inspector_athena_output_bucket"
+ENVIRONMENT_VARIABLE = "bundle_inspector_environment"
+USER_VARIABLE = "bundle_inspector_user"
+
+QUERY_ID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+S3PROXY_ALLOWED_SUFFIXES = (".pmtiles", ".parquet", ".json", ".csv", ".md")
+
+
+class ApiError(Exception):
+    """Raised by an endpoint function; adapters translate this to an HTTP error."""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+class S3ObjectResponse:
+    """Headers plus an optional body stream for a proxied S3 object.
+
+    ``body`` is ``None`` for HEAD requests (headers only).
+    """
+
+    def __init__(self, headers: dict, status: int, body=None):
+        self.headers = headers
+        self.status = status
+        self.body = body
+
+
+@lru_cache(maxsize=1)
+def _s3_client():
+    import boto3
+
+    return boto3.client("s3")
+
+
+def get_config(user_override: str | None = None) -> dict:
+    """Read bucket and namespace config from Airflow Variables.
+
+    Called inside request handlers, never at import time, to avoid hitting
+    the metadata DB during plugin loading.
+
+    The environment is read from the ``bundle_inspector_environment``
+    Airflow Variable so the namespace decision uses the same source of
+    truth. In ``dev``, the namespace is taken from the
+    ``bundle_inspector_user`` Airflow Variable (or overridden by
+    ``user_override``).
+    """
+    bucket = Variable.get(S3_BUCKET_VARIABLE)
+    athena_output_bucket = Variable.get(ATHENA_OUTPUT_BUCKET_VARIABLE, default_var=None)
+    environment = Variable.get(ENVIRONMENT_VARIABLE, default_var="dev")
+    if environment == "dev":
+        namespace = (
+            user_override
+            if user_override is not None
+            else Variable.get(USER_VARIABLE, default_var="")
+        )
+    else:
+        namespace = ""
+    namespace_prefix = f"{namespace}/" if namespace else ""
+    return {
+        "bucket": bucket,
+        "athena_output_bucket": athena_output_bucket,
+        "environment": environment,
+        "namespace": namespace,
+        "namespace_prefix": namespace_prefix,
+    }
+
+
+def config(user: str | None) -> dict:
+    """Return bucket, environment, and namespace for display."""
+    cfg = get_config(user_override=user)
+    return {
+        "bucket": cfg["bucket"],
+        "environment": cfg["environment"],
+        "namespace": cfg["namespace"],
+        "aws_region": os.environ.get("AWS_REGION", "us-west-2"),
+    }
+
+
+def list_children(prefix: str, user: str | None) -> dict:
+    """List children at a given prefix in the bundle hierarchy.
+
+    Args:
+        prefix: Relative path from namespace root (e.g. "theme_promote/theme=places/").
+            Empty string returns the known pipeline stages.
+        user: Override namespace (dev only).
+    """
+    cfg = get_config(user_override=user)
+    depth = s3.get_depth(prefix)
+
+    # Root listing: return known stages as synthetic entries (no S3 call)
+    if depth == 0:
+        children = [{"name": f"{s}/", "type": "directory"} for s in s3.KNOWN_STAGES]
+        return {
+            "prefix": prefix,
+            "depth": depth,
+            "has_success": False,
+            "has_metadata": False,
+            "children": children,
+        }
+
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    items = s3.list_prefix(client, cfg["bucket"], full_prefix)
+
+    # Determine stage from the first segment of the prefix
+    stage = prefix.split("/")[0]
+    relative_depth = depth - 1  # depth within the stage hierarchy
+    filtered = s3.filter_bundle_level(items, stage, relative_depth)
+
+    has_success = any(item["name"] == "success" for item in items)
+    has_metadata = any(item["name"] == "metadata.json" for item in items)
+
+    return {
+        "prefix": prefix,
+        "depth": depth,
+        "stage": stage,
+        "run_depth": s3.run_depth_for_stage(stage),
+        "hierarchy": s3.hierarchy_for_stage(stage),
+        "has_success": has_success,
+        "has_metadata": has_metadata,
+        "children": filtered,
+    }
+
+
+def list_users() -> dict:
+    """List user namespaces (top-level prefixes). Only useful in dev."""
+    cfg = get_config()
+    if cfg["environment"] != "dev":
+        return {"users": []}
+    client = _s3_client()
+    return {"users": s3.list_users(client, cfg["bucket"])}
+
+
+def theme_types(prefix: str, user: str | None) -> dict:
+    """Discover theme=X/type=Y/ Hive partitions under a component prefix.
+
+    Recurses through any non-theme, non-type partition levels (e.g.
+    ``dataset=``) until it reaches ``theme=`` directories or leaf data. The
+    returned ``theme_dirs`` values include the full relative sub-path so the
+    frontend can build narrowed prefixes without knowing the intermediate
+    structure.
+
+    Args:
+        prefix: Relative path to a component (e.g. ".../partition_bboxes/").
+        user: Override namespace (dev only).
+    """
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+
+    def partition_value(name):
+        """Extract the value from a Hive partition or bare directory name."""
+        stripped = name.rstrip("/")
+        if "=" in stripped:
+            return stripped.split("=", 1)[1]
+        return stripped
+
+    def find_theme_dirs(s3_prefix, path_so_far="", labels_so_far=()):
+        """Recurse until we find theme= or bare (non-Hive) directories.
+
+        Returns a list of (label, relative_path) tuples where label is
+        a composite of all partition values along the path (e.g.
+        "DadosAbertos / buildings") and relative_path is the full
+        sub-path from the component root.
+        """
+        items = s3.list_prefix(client, cfg["bucket"], s3_prefix)
+        dirs = [d for d in items if d["type"] == "directory" and not d["name"].startswith(".")]
+
+        # theme_stage uses bare dir names ("buildings/") instead of
+        # Hive-style ("theme=buildings/"). Detect both.
+        theme_dirs_here = [
+            d for d in dirs if d["name"].startswith("theme=") or "=" not in d["name"]
+        ]
+
+        if theme_dirs_here:
+            result = []
+            for d in theme_dirs_here:
+                dir_name = d["name"].rstrip("/")
+                val = partition_value(dir_name)
+                label = " / ".join((*labels_so_far, val)) if labels_so_far else val
+                rel = f"{path_so_far}/{dir_name}" if path_so_far else dir_name
+                result.append((label, rel))
+            return sorted(result, key=lambda e: e[0])
+
+        # No theme= dirs found -- recurse through other partition dirs
+        result = []
+        for d in dirs:
+            dir_name = d["name"].rstrip("/")
+            val = partition_value(dir_name)
+            child_prefix = f"{s3_prefix}{dir_name}/"
+            child_path = f"{path_so_far}/{dir_name}" if path_so_far else dir_name
+            result.extend(find_theme_dirs(child_prefix, child_path, (*labels_so_far, val)))
+        return sorted(result, key=lambda e: e[0])
+
+    theme_entries = find_theme_dirs(full_prefix)
+
+    themes = []  # display labels (e.g. "DadosAbertos / buildings")
+    theme_dirs = []  # relative sub-paths (for building prefixes)
+    types_by_theme = {}  # keyed by display label (unique due to composite)
+    for label, rel_path in theme_entries:
+        themes.append(label)
+        theme_dirs.append(rel_path)
+        theme_prefix = f"{full_prefix}{rel_path}/"
+        children = s3.list_prefix(client, cfg["bucket"], theme_prefix)
+        type_entries = sorted(
+            (partition_value(d["name"]), d["name"].rstrip("/"))
+            for d in children
+            if d["type"] == "directory" and d["name"].startswith("type=")
+        )
+        types_by_theme[label] = [e[1] for e in type_entries]
+
+    return {
+        "themes": themes,
+        "theme_dirs": theme_dirs,
+        "types_by_theme": types_by_theme,
+    }
+
+
+def count(prefix: str, user: str | None) -> dict:
+    """Count objects under a prefix (for component detail view)."""
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    total = s3.count_objects(client, cfg["bucket"], full_prefix)
+    return {"prefix": prefix, "count": total}
+
+
+def tree(prefix: str, user: str | None) -> dict:
+    """Return an abridged directory tree under a prefix."""
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    return s3.list_tree(client, cfg["bucket"], full_prefix)
+
+
+def component_data(prefix: str, user: str | None) -> dict:
+    """Load parquet data from a component and return as GeoJSON."""
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    try:
+        return s3.load_parquet_geojson(client, cfg["bucket"], full_prefix)
+    except Exception as e:
+        raise ApiError(500, str(e)) from e
+
+
+def parquet_stats(prefix: str, user: str | None) -> dict:
+    """File count, size stats, and schema for parquet files under a prefix."""
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    try:
+        return s3.parquet_stats(client, cfg["bucket"], full_prefix)
+    except Exception as e:
+        raise ApiError(500, str(e)) from e
+
+
+def presign(prefix: str, suffix: str, user: str | None) -> dict:
+    """Generate a presigned S3 URL for a file under a component prefix."""
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    url = s3.presign_file(client, cfg["bucket"], full_prefix, suffix)
+    if not url:
+        raise ApiError(404, "No matching file found")
+    return {"url": url}
+
+
+def resolve(prefix: str, suffix: str, user: str | None) -> dict:
+    """Find a file by suffix under a prefix and return its key.
+
+    Returns the key relative to the namespace prefix, for use with s3proxy.
+    """
+    cfg = get_config(user_override=user)
+    full_prefix = f"{cfg['namespace_prefix']}{prefix}"
+    client = _s3_client()
+    full_key = s3.find_file_key(client, cfg["bucket"], full_prefix, suffix)
+    if not full_key:
+        raise ApiError(404, "No matching file found")
+    ns = cfg["namespace_prefix"]
+    relative_key = full_key[len(ns) :] if full_key.startswith(ns) else full_key
+    return {"key": relative_key}
+
+
+def s3proxy(
+    key: str, user: str | None, range_header: str | None, head_only: bool
+) -> S3ObjectResponse:
+    """Proxy (optionally ranged) requests to an object under the user's namespace.
+
+    Restricted to an allowlist of file extensions and rejects path traversal,
+    since the key is attacker-controlled input from the browser.
+    """
+    if not key:
+        raise ApiError(400, "key is required")
+    if ".." in key or key.startswith("/"):
+        raise ApiError(400, "invalid key")
+    if not key.endswith(S3PROXY_ALLOWED_SUFFIXES):
+        raise ApiError(400, f"key must end with one of {S3PROXY_ALLOWED_SUFFIXES}")
+
+    cfg = get_config(user_override=user)
+    full_key = f"{cfg['namespace_prefix']}{key}"
+    client = _s3_client()
+    params = {"Bucket": cfg["bucket"], "Key": full_key}
+
+    if head_only:
+        try:
+            head_resp = client.head_object(**params)
+        except Exception as e:
+            raise ApiError(404, str(e)) from e
+        return S3ObjectResponse(
+            headers={
+                "Content-Type": head_resp.get("ContentType", "application/octet-stream"),
+                "Content-Length": str(head_resp["ContentLength"]),
+                "Accept-Ranges": "bytes",
+            },
+            status=200,
+        )
+
+    if range_header:
+        params["Range"] = range_header
+
+    try:
+        resp = client.get_object(**params)
+    except Exception as e:
+        raise ApiError(404, str(e)) from e
+
+    headers = {
+        "Content-Type": resp.get("ContentType", "application/octet-stream"),
+        "Content-Length": str(resp["ContentLength"]),
+        "Accept-Ranges": "bytes",
+    }
+    if "ContentRange" in resp:
+        headers["Content-Range"] = resp["ContentRange"]
+
+    return S3ObjectResponse(
+        headers=headers,
+        status=206 if range_header else 200,
+        body=_stream_s3_body(resp["Body"]),
+    )
+
+
+def _stream_s3_body(body, chunk_size: int = 65536):
+    """Yield chunks from an S3 streaming body, closing it when exhausted."""
+    try:
+        while True:
+            chunk = body.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        body.close()
+
+
+def athena_query(sql: str, user: str | None) -> dict:
+    """Start an Athena query and return the execution ID.
+
+    The browser polls ``athena_query_status`` until the query completes.
+    """
+    if not sql:
+        raise ApiError(400, "sql is required")
+    cfg = get_config(user_override=user)
+    output_bucket = cfg["athena_output_bucket"] or (
+        f"overture-bundle-inspector-athena-output-{cfg['environment']}"
+    )
+    result = s3.athena_start(output_bucket, sql)
+    if "error" in result:
+        raise ApiError(400, result["error"])
+    return result
+
+
+def _validate_query_id(query_id: str) -> None:
+    if not query_id:
+        raise ApiError(400, "query_id is required")
+    if not QUERY_ID_PATTERN.match(query_id):
+        raise ApiError(400, "invalid query_id")
+
+
+def athena_query_status(query_id: str) -> dict:
+    """Check the status of an Athena query execution.
+
+    Returns state (QUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED). On
+    SUCCEEDED, includes query_id and download_url. On FAILED/CANCELLED,
+    includes error.
+    """
+    _validate_query_id(query_id)
+    result = s3.athena_status(query_id)
+    if "error" in result:
+        raise ApiError(400, result["error"])
+    return result
+
+
+def athena_csv_proxy(query_id: str, range_header: str | None, head_only: bool) -> S3ObjectResponse:
+    """Proxy (optionally ranged) requests to an Athena result CSV on S3."""
+    _validate_query_id(query_id)
+
+    try:
+        location = s3.athena_output_location(query_id)
+    except Exception as e:
+        raise ApiError(502, "failed to look up Athena output location") from e
+    if location is None:
+        raise ApiError(404, "no result location found for query_id")
+
+    output_bucket, key = location
+    client = _s3_client()
+    params = {"Bucket": output_bucket, "Key": key}
+
+    if head_only:
+        try:
+            head_resp = client.head_object(**params)
+        except Exception as e:
+            raise ApiError(404, str(e)) from e
+        return S3ObjectResponse(
+            headers={
+                "Content-Type": "text/csv",
+                "Content-Length": str(head_resp["ContentLength"]),
+                "Accept-Ranges": "bytes",
+            },
+            status=200,
+        )
+
+    if range_header:
+        params["Range"] = range_header
+
+    try:
+        resp = client.get_object(**params)
+    except Exception as e:
+        raise ApiError(404, str(e)) from e
+
+    headers = {
+        "Content-Type": "text/csv",
+        "Content-Length": str(resp["ContentLength"]),
+        "Accept-Ranges": "bytes",
+    }
+    if "ContentRange" in resp:
+        headers["Content-Range"] = resp["ContentRange"]
+
+    return S3ObjectResponse(
+        headers=headers,
+        status=206 if range_header else 200,
+        body=_stream_s3_body(resp["Body"]),
+    )

--- a/src/overture_airflow_provider/plugins/bundle_inspector/fastapi_app.py
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/fastapi_app.py
@@ -1,0 +1,175 @@
+"""Airflow 3 (FastAPI) adapter for the bundle inspector plugin.
+
+Only imported when FastAPI and Airflow's FastAPI auth dependency are
+available (Airflow 3's API server). Route handlers are thin wrappers over
+:mod:`_endpoints`; the actual S3/Airflow-Variable logic lives there so it
+has no FastAPI dependency and stays shared with the Airflow 2 (Flask)
+adapter in ``flask_app.py``.
+
+Endpoints require an authenticated Airflow user (any user who can reach the
+API server's session, via ``airflow.api_fastapi.core_api.security.GetUserDep``)
+rather than a per-DAG authorization check: bundle browsing isn't scoped to a
+single DAG, so there is no ``dag_id`` to authorize against the way Airflow 2's
+``has_access_dag`` did.
+"""
+
+import pathlib
+
+from airflow.api_fastapi.core_api.security import GetUserDep
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import _endpoints as ep
+
+_PLUGIN_ROOT = pathlib.Path(__file__).parent
+_templates = Jinja2Templates(directory=str(_PLUGIN_ROOT / "templates" / "bundle_inspector"))
+
+
+def _error_response(e: ep.ApiError):
+    from fastapi.responses import JSONResponse
+
+    return JSONResponse({"error": e.message}, status_code=e.status)
+
+
+def _s3_object_response(result: ep.S3ObjectResponse):
+    if result.body is None:
+        return Response(status_code=result.status, headers=result.headers)
+    return StreamingResponse(result.body, status_code=result.status, headers=result.headers)
+
+
+def build_ui_app() -> FastAPI:
+    """Serve the Bundle Inspector index page and its static assets."""
+    app = FastAPI(openapi_url=None)
+    app.mount(
+        "/static/bundle_inspector",
+        StaticFiles(directory=str(_PLUGIN_ROOT / "static" / "bundle_inspector")),
+        name="bundle_inspector_static",
+    )
+
+    @app.get("/", response_class=HTMLResponse)
+    @app.get("/{subpath:path}", response_class=HTMLResponse)
+    def index(request: Request, subpath: str | None = None, user: GetUserDep = None):
+        return _templates.TemplateResponse(request, "index.html")
+
+    return app
+
+
+def build_api_app() -> FastAPI:
+    """Expose the same JSON/streaming endpoints as the Airflow 2 Flask blueprint."""
+    app = FastAPI(openapi_url=None)
+
+    @app.get("/config")
+    def config(user: GetUserDep, request: Request):
+        return ep.config(request.query_params.get("user"))
+
+    @app.get("/list")
+    def list_children(user: GetUserDep, request: Request):
+        try:
+            return ep.list_children(
+                request.query_params.get("prefix", ""), request.query_params.get("user")
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.get("/users")
+    def users(user: GetUserDep):
+        return ep.list_users()
+
+    @app.get("/theme-types")
+    def theme_types(user: GetUserDep, request: Request):
+        return ep.theme_types(
+            request.query_params.get("prefix", ""), request.query_params.get("user")
+        )
+
+    @app.get("/count")
+    def count(user: GetUserDep, request: Request):
+        return ep.count(request.query_params.get("prefix", ""), request.query_params.get("user"))
+
+    @app.get("/tree")
+    def tree(user: GetUserDep, request: Request):
+        return ep.tree(request.query_params.get("prefix", ""), request.query_params.get("user"))
+
+    @app.get("/component-data")
+    def component_data(user: GetUserDep, request: Request):
+        try:
+            return ep.component_data(
+                request.query_params.get("prefix", ""), request.query_params.get("user")
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.get("/parquet-stats")
+    def parquet_stats_endpoint(user: GetUserDep, request: Request):
+        try:
+            return ep.parquet_stats(
+                request.query_params.get("prefix", ""), request.query_params.get("user")
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.get("/presign")
+    def presign(user: GetUserDep, request: Request):
+        try:
+            return ep.presign(
+                request.query_params.get("prefix", ""),
+                request.query_params.get("suffix", ".pmtiles"),
+                request.query_params.get("user"),
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.get("/resolve")
+    def resolve(user: GetUserDep, request: Request):
+        try:
+            return ep.resolve(
+                request.query_params.get("prefix", ""),
+                request.query_params.get("suffix", ".pmtiles"),
+                request.query_params.get("user"),
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.api_route("/s3proxy", methods=["GET", "HEAD"])
+    def s3proxy(user: GetUserDep, request: Request):
+        try:
+            result = ep.s3proxy(
+                request.query_params.get("key", ""),
+                request.query_params.get("user"),
+                request.headers.get("Range"),
+                request.method == "HEAD",
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+        return _s3_object_response(result)
+
+    @app.get("/athena-query")
+    def athena_query_endpoint(user: GetUserDep, request: Request):
+        try:
+            return ep.athena_query(
+                request.query_params.get("sql", ""), request.query_params.get("user")
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.get("/athena-status")
+    def athena_status_endpoint(user: GetUserDep, request: Request):
+        try:
+            return ep.athena_query_status(request.query_params.get("query_id", ""))
+        except ep.ApiError as e:
+            return _error_response(e)
+
+    @app.api_route("/athena-csv", methods=["GET", "HEAD"])
+    def athena_csv_proxy(user: GetUserDep, request: Request):
+        try:
+            result = ep.athena_csv_proxy(
+                request.query_params.get("query_id", ""),
+                request.headers.get("Range"),
+                request.method == "HEAD",
+            )
+        except ep.ApiError as e:
+            return _error_response(e)
+        return _s3_object_response(result)
+
+    return app

--- a/src/overture_airflow_provider/plugins/bundle_inspector/flask_app.py
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/flask_app.py
@@ -1,0 +1,160 @@
+"""Airflow 2 (Flask/FAB) adapter for the bundle inspector plugin.
+
+Only imported when Flask and ``airflow.www.auth`` are available (Airflow 2's
+webserver). Route handlers are thin wrappers over :mod:`_endpoints`; the
+actual S3/Airflow-Variable logic lives there so it has no Flask dependency.
+"""
+
+from airflow.www.auth import has_access_dag
+from flask import Blueprint, Response, jsonify, render_template, request
+
+from . import _endpoints as ep
+
+bundle_inspector_bp = Blueprint(
+    "bundle_inspector",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    static_url_path="/static",
+    url_prefix="/bundle-inspector",
+)
+
+
+@bundle_inspector_bp.route("/")
+@bundle_inspector_bp.route("/<path:subpath>")
+@has_access_dag("GET")
+def index(subpath=None):
+    """Render the Bundle Inspector view."""
+    return render_template("bundle_inspector/index.html")
+
+
+bundle_inspector_api_bp = Blueprint(
+    "bundle_inspector_api",
+    __name__,
+    url_prefix="/api/bundle-inspector",
+)
+
+
+def _handle(fn, *args, **kwargs):
+    """Call an ``_endpoints`` function and translate ``ApiError`` to a JSON response."""
+    try:
+        return jsonify(fn(*args, **kwargs))
+    except ep.ApiError as e:
+        return jsonify({"error": e.message}), e.status
+
+
+def _s3_object_response(result: ep.S3ObjectResponse) -> Response:
+    if result.body is None:
+        return Response(status=result.status, headers=result.headers)
+    return Response(result.body, status=result.status, headers=result.headers)
+
+
+@bundle_inspector_api_bp.route("/config", methods=["GET"])
+@has_access_dag("GET")
+def config():
+    return _handle(ep.config, request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/list", methods=["GET"])
+@has_access_dag("GET")
+def list_children():
+    return _handle(ep.list_children, request.args.get("prefix", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/users", methods=["GET"])
+@has_access_dag("GET")
+def users():
+    return _handle(ep.list_users)
+
+
+@bundle_inspector_api_bp.route("/theme-types", methods=["GET"])
+@has_access_dag("GET")
+def theme_types():
+    return _handle(ep.theme_types, request.args.get("prefix", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/count", methods=["GET"])
+@has_access_dag("GET")
+def count():
+    return _handle(ep.count, request.args.get("prefix", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/tree", methods=["GET"])
+@has_access_dag("GET")
+def tree():
+    return _handle(ep.tree, request.args.get("prefix", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/component-data", methods=["GET"])
+@has_access_dag("GET")
+def component_data():
+    return _handle(ep.component_data, request.args.get("prefix", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/parquet-stats", methods=["GET"])
+@has_access_dag("GET")
+def parquet_stats_endpoint():
+    return _handle(ep.parquet_stats, request.args.get("prefix", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/presign", methods=["GET"])
+@has_access_dag("GET")
+def presign():
+    return _handle(
+        ep.presign,
+        request.args.get("prefix", ""),
+        request.args.get("suffix", ".pmtiles"),
+        request.args.get("user"),
+    )
+
+
+@bundle_inspector_api_bp.route("/resolve", methods=["GET"])
+@has_access_dag("GET")
+def resolve():
+    return _handle(
+        ep.resolve,
+        request.args.get("prefix", ""),
+        request.args.get("suffix", ".pmtiles"),
+        request.args.get("user"),
+    )
+
+
+@bundle_inspector_api_bp.route("/s3proxy", methods=["GET", "HEAD"])
+@has_access_dag("GET")
+def s3proxy():
+    try:
+        result = ep.s3proxy(
+            request.args.get("key", ""),
+            request.args.get("user"),
+            request.headers.get("Range"),
+            request.method == "HEAD",
+        )
+    except ep.ApiError as e:
+        return jsonify({"error": e.message}), e.status
+    return _s3_object_response(result)
+
+
+@bundle_inspector_api_bp.route("/athena-query", methods=["GET"])
+@has_access_dag("GET")
+def athena_query_endpoint():
+    return _handle(ep.athena_query, request.args.get("sql", ""), request.args.get("user"))
+
+
+@bundle_inspector_api_bp.route("/athena-status", methods=["GET"])
+@has_access_dag("GET")
+def athena_status_endpoint():
+    return _handle(ep.athena_query_status, request.args.get("query_id", ""))
+
+
+@bundle_inspector_api_bp.route("/athena-csv", methods=["GET", "HEAD"])
+@has_access_dag("GET")
+def athena_csv_proxy():
+    try:
+        result = ep.athena_csv_proxy(
+            request.args.get("query_id", ""),
+            request.headers.get("Range"),
+            request.method == "HEAD",
+        )
+    except ep.ApiError as e:
+        return jsonify({"error": e.message}), e.status
+    return _s3_object_response(result)

--- a/src/overture_airflow_provider/plugins/bundle_inspector/s3.py
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/s3.py
@@ -1,0 +1,485 @@
+"""S3 listing, filtering, and path parsing for the bundle inspector."""
+
+import io
+import json
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Update when pipeline stages change. See STAGE_HIERARCHY below for valid stages.
+KNOWN_STAGES = ["theme_promote", "theme_stage", "release_candidate"]
+
+STAGE_HIERARCHY = {
+    "theme_promote": ["theme", "schema", "run"],
+    "theme_stage": ["theme", "run"],
+    "release_candidate": ["release", "run"],
+}
+DEFAULT_HIERARCHY = ["theme", "schema", "run"]
+
+
+def get_depth(prefix: str) -> int:
+    """Return the depth of a prefix in the bundle hierarchy.
+
+    Depth 0 is root (empty prefix). Each trailing-slash segment adds one.
+    """
+    if not prefix:
+        return 0
+    return prefix.rstrip("/").count("/") + 1
+
+
+def hierarchy_for_stage(stage: str) -> list[str]:
+    """Return the hierarchy levels for a stage."""
+    return STAGE_HIERARCHY.get(stage, DEFAULT_HIERARCHY)
+
+
+def run_depth_for_stage(stage: str) -> int:
+    """Return the depth at which run-level nodes appear for a stage.
+
+    The hierarchy lists levels under the stage, so the run-level depth is
+    1 (for the stage itself) + index of "run" + 1.
+    """
+    h = hierarchy_for_stage(stage)
+    try:
+        return h.index("run") + 2  # +1 for stage prefix, +1 for 1-based depth
+    except ValueError:
+        return len(h) + 1
+
+
+def _pattern_for_level(level_name: str) -> re.Pattern:
+    """Return a regex pattern matching a directory for a hierarchy level.
+
+    Levels prefixed with ``!`` match bare directory names (no key=value).
+    theme_stage uses bare theme dirs until it is standardized.
+    """
+    if level_name.startswith("!"):
+        # Bare directory: match anything that is NOT a Hive partition
+        return re.compile(r"^[^=]+/$")
+    return re.compile(rf"^{re.escape(level_name)}=.+/$")
+
+
+# Components to show at the run level for each stage.
+# None means show everything (no filtering).
+STAGE_COMPONENTS = {
+    "theme_stage": {"data/", "success", "metadata.json", "summary.md"},
+}
+
+
+def filter_bundle_level(items: list[dict], stage: str, depth: int) -> list[dict]:
+    """Filter listing results to match expected bundle hierarchy patterns.
+
+    Uses the stage's hierarchy to determine what pattern to expect at each
+    relative depth (0-indexed from the first level inside the stage).
+    At component level (depth == len(hierarchy)), applies STAGE_COMPONENTS
+    allowlist if one exists for the stage.
+    Negative depths pass everything through.
+    """
+    h = hierarchy_for_stage(stage)
+    if depth < 0:
+        return items
+    if depth >= len(h):
+        allowed = STAGE_COMPONENTS.get(stage)
+        if allowed is not None:
+            return [item for item in items if item["name"] in allowed]
+        return items
+    pattern = _pattern_for_level(h[depth])
+    return [item for item in items if pattern.match(item["name"])]
+
+
+def list_prefix(client, bucket: str, prefix: str) -> list[dict]:
+    """List immediate children at an S3 prefix.
+
+    Args:
+        client: boto3 S3 client
+        bucket: S3 bucket name
+        prefix: Full S3 prefix (e.g. "adam/theme_promote/"). Child names
+            are returned relative to this prefix.
+
+    Returns:
+        List of dicts with name, type, and optionally size/last_modified.
+    """
+    paginator = client.get_paginator("list_objects_v2")
+    items = []
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/"):
+        for cp in page.get("CommonPrefixes", []):
+            full = cp["Prefix"]
+            name = full[len(prefix) :]
+            items.append({"name": name, "type": "directory"})
+
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            name = key[len(prefix) :]
+            if not name:
+                continue
+            items.append(
+                {
+                    "name": name,
+                    "type": "file",
+                    "size": obj["Size"],
+                    "last_modified": obj["LastModified"].isoformat(),
+                }
+            )
+
+    return items
+
+
+def list_users(client, bucket: str) -> list[str]:
+    """List top-level prefixes in the bucket (user namespaces in dev)."""
+    paginator = client.get_paginator("list_objects_v2")
+    users = []
+    for page in paginator.paginate(Bucket=bucket, Prefix="", Delimiter="/"):
+        users.extend(cp["Prefix"].rstrip("/") for cp in page.get("CommonPrefixes", []))
+    return users
+
+
+def count_objects(client, bucket: str, prefix: str) -> int:
+    """Count objects under a prefix (non-recursive via pagination)."""
+    paginator = client.get_paginator("list_objects_v2")
+    total = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        total += page.get("KeyCount", 0)
+    return total
+
+
+def list_tree(
+    client,
+    bucket: str,
+    prefix: str,
+    max_keys: int = 5000,
+    max_files_per_dir: int = 3,
+) -> dict:
+    """Build an abridged directory tree under *prefix*.
+
+    Lists up to *max_keys* objects (no delimiter), groups them into a
+    nested tree, and truncates each directory to *max_files_per_dir*
+    leaf files. Directories that had files omitted include an
+    ``"_omitted"`` count.
+
+    Returns a dict of ``{"dirs": {...}, "files": [...], "_omitted": N}``
+    where ``dirs`` maps directory names to nested dicts of the same shape.
+    """
+    paginator = client.get_paginator("list_objects_v2")
+    keys: list[str] = []
+
+    for page in paginator.paginate(
+        Bucket=bucket, Prefix=prefix, PaginationConfig={"MaxItems": max_keys}
+    ):
+        for obj in page.get("Contents", []):
+            rel = obj["Key"][len(prefix) :]
+            if rel:
+                keys.append(rel)
+
+    root: dict = {"dirs": {}, "files": []}
+
+    for key in keys:
+        parts = key.split("/")
+        node = root
+        for part in parts[:-1]:
+            if part not in node["dirs"]:
+                node["dirs"][part] = {"dirs": {}, "files": []}
+            node = node["dirs"][part]
+        filename = parts[-1]
+        if filename:
+            node["files"].append(filename)
+
+    def _trim(node: dict) -> dict:
+        trimmed_dirs = {}
+        for name in sorted(node["dirs"]):
+            trimmed_dirs[name] = _trim(node["dirs"][name])
+        total_files = len(node["files"])
+        kept = sorted(node["files"])[:max_files_per_dir]
+        result: dict = {"dirs": trimmed_dirs, "files": kept}
+        omitted = total_files - len(kept)
+        if omitted > 0:
+            result["_omitted"] = omitted
+        return result
+
+    trimmed = _trim(root)
+    trimmed["_total_keys"] = len(keys)
+    trimmed["_truncated"] = len(keys) >= max_keys
+    return trimmed
+
+
+# -- Parquet / GeoJSON loading ------------------------------------------------
+
+
+def _wkb_to_geojson(wkb: bytes) -> dict | None:
+    """Convert WKB bytes to a GeoJSON geometry dict via shapely."""
+    if not wkb:
+        return None
+    try:
+        from shapely import wkb as shapely_wkb
+        from shapely.geometry import mapping
+
+        geom = shapely_wkb.loads(wkb)
+        return mapping(geom)
+    except Exception:
+        logger.warning("Failed to parse WKB geometry (%d bytes)", len(wkb))
+        return None
+
+
+def load_parquet_geojson(client, bucket: str, prefix: str) -> dict:
+    """Sample the first parquet file under a prefix and return a GeoJSON FeatureCollection.
+
+    Reads only the first discovered parquet file (up to MAX_ROWS rows).
+    Handles two formats:
+    - GeoParquet with a WKB geometry column (detected via Arrow metadata)
+    - Plain columns named xmin/ymin/xmax/ymax (converted to bbox polygons)
+    """
+    # Recursive listing (no delimiter) to find parquet files at any depth
+    paginator = client.get_paginator("list_objects_v2")
+    parquet_keys = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".parquet"):
+                parquet_keys.append(obj["Key"])
+    if not parquet_keys:
+        return {"type": "FeatureCollection", "features": []}
+
+    import pyarrow.parquet as pq
+
+    MAX_ROWS = 10_000
+
+    key = parquet_keys[0]
+    response = client.get_object(Bucket=bucket, Key=key)
+    table = pq.read_table(io.BytesIO(response["Body"].read()))
+    if len(table) > MAX_ROWS:
+        logger.warning("Parquet %s has %d rows, truncating to %d", key, len(table), MAX_ROWS)
+        table = table.slice(0, MAX_ROWS)
+
+    # Detect geometry column from GeoParquet metadata
+    geo_col = None
+    arrow_meta = table.schema.metadata or {}
+    geo_meta = arrow_meta.get(b"geo")
+    if geo_meta:
+        geo_col = json.loads(geo_meta).get("primary_column", "geometry")
+    elif "geometry" in table.column_names:
+        geo_col = "geometry"
+
+    # Convert via to_pylist() so values are native Python types (JSON-serializable)
+    data = {c: table.column(c).to_pylist() for c in table.column_names}
+
+    features = []
+
+    if geo_col and geo_col in table.column_names:
+        geo_values = data.pop(geo_col)
+        prop_cols = list(data.keys())
+        for i, wkb in enumerate(geo_values):
+            geom = _wkb_to_geojson(wkb)
+            props = {c: data[c][i] for c in prop_cols}
+            features.append({"type": "Feature", "geometry": geom, "properties": props})
+    elif all(c in data for c in ("xmin", "ymin", "xmax", "ymax")):
+        bbox_cols = {"xmin", "ymin", "xmax", "ymax"}
+        prop_cols = [c for c in data if c not in bbox_cols]
+        for i in range(len(table)):
+            xmin, ymin = data["xmin"][i], data["ymin"][i]
+            xmax, ymax = data["xmax"][i], data["ymax"][i]
+            props = {c: data[c][i] for c in prop_cols}
+            features.append(
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [xmin, ymin],
+                                [xmax, ymin],
+                                [xmax, ymax],
+                                [xmin, ymax],
+                                [xmin, ymin],
+                            ]
+                        ],
+                    },
+                    "properties": props,
+                }
+            )
+
+    return {"type": "FeatureCollection", "features": features}
+
+
+def parquet_stats(client, bucket: str, prefix: str) -> dict:
+    """Compute file stats and read schema from parquet files under a prefix.
+
+    Returns dict with file_count, total_size, min_size, max_size, avg_size,
+    and schema (list of {name, type} dicts from the first file's Arrow schema).
+    """
+    paginator = client.get_paginator("list_objects_v2")
+    sizes = []
+    first_key = None
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".parquet"):
+                sizes.append(obj["Size"])
+                if first_key is None:
+                    first_key = obj["Key"]
+
+    if not sizes:
+        return {"file_count": 0}
+
+    schema_fields = []
+    if first_key:
+        try:
+            import pyarrow.parquet as pq
+
+            # Read only the Parquet footer via boto3 (avoids PyArrow's S3
+            # filesystem which doesn't inherit boto3's credentials).
+            # Footer layout: [...data...][footer thrift][footer_len 4B LE]["PAR1" 4B]
+            file_size = client.head_object(Bucket=bucket, Key=first_key)["ContentLength"]
+            trailer = client.get_object(
+                Bucket=bucket,
+                Key=first_key,
+                Range=f"bytes={file_size - 8}-{file_size - 1}",
+            )["Body"].read()
+            footer_len = int.from_bytes(trailer[:4], "little")
+            footer_start = file_size - footer_len - 8
+            footer_bytes = client.get_object(
+                Bucket=bucket,
+                Key=first_key,
+                Range=f"bytes={footer_start}-{file_size - 1}",
+            )["Body"].read()
+            # BytesIO containing only the footer + trailer: pq.read_metadata
+            # reads offsets from the end, so this works without the full file.
+            metadata = pq.read_metadata(io.BytesIO(footer_bytes))
+            schema = metadata.schema.to_arrow_schema()
+            for field in schema:
+                schema_fields.append({"name": field.name, "type": str(field.type)})
+        except Exception as e:
+            logger.warning("Failed to read parquet schema from %s: %s", first_key, e)
+
+    return {
+        "file_count": len(sizes),
+        "total_size": sum(sizes),
+        "min_size": min(sizes),
+        "max_size": max(sizes),
+        "avg_size": sum(sizes) // len(sizes),
+        "schema": schema_fields,
+    }
+
+
+def find_file_key(client, bucket: str, prefix: str, suffix: str) -> str | None:
+    """Find the first file matching suffix under prefix and return its S3 key."""
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(suffix):
+                return obj["Key"]
+    return None
+
+
+def presign_file(client, bucket: str, prefix: str, suffix: str, expires: int = 3600) -> str | None:
+    """Find a file matching suffix under prefix and return a presigned GET URL."""
+    key = find_file_key(client, bucket, prefix, suffix)
+    if key:
+        return client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=expires,
+        )
+    return None
+
+
+# -- Athena query --------------------------------------------------------
+
+
+def _parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Split an ``s3://bucket/key`` URI into a ``(bucket, key)`` tuple."""
+    if not uri.startswith("s3://"):
+        raise ValueError(f"not an s3:// URI: {uri!r}")
+    bucket, _, key = uri.removeprefix("s3://").partition("/")
+    if not bucket or not key:
+        raise ValueError(f"malformed s3:// URI: {uri!r}")
+    return bucket, key
+
+
+def athena_start(output_bucket: str, sql: str) -> dict:
+    """Start an Athena query and return the execution ID.
+
+    Returns:
+        Dict with "query_id" on success, or "error" on failure.
+    """
+    import boto3
+
+    output_location = f"s3://{output_bucket}/athena_results/"
+    client = boto3.client("athena")
+
+    try:
+        resp = client.start_query_execution(
+            QueryString=sql,
+            ResultConfiguration={"OutputLocation": output_location},
+        )
+    except Exception as e:
+        return {"error": str(e)}
+
+    return {"query_id": resp["QueryExecutionId"]}
+
+
+def athena_output_location(query_id: str) -> tuple[str, str] | None:
+    """Look up the actual (bucket, key) of a query's result CSV.
+
+    Reads ``QueryExecution.ResultConfiguration.OutputLocation`` from
+    GetQueryExecution rather than assuming a path, since a workgroup with
+    enforced configuration silently redirects results to its own configured
+    location regardless of what the query requested.
+
+    Returns:
+        ``(bucket, key)``, or ``None`` if the query execution has no
+        recorded output location.
+    """
+    import boto3
+
+    client = boto3.client("athena")
+    resp = client.get_query_execution(QueryExecutionId=query_id)
+    location = resp["QueryExecution"].get("ResultConfiguration", {}).get("OutputLocation")
+    if not location:
+        return None
+    return _parse_s3_uri(location)
+
+
+def athena_status(query_id: str) -> dict:
+    """Check the status of an Athena query execution.
+
+    Returns:
+        Dict with "state" (QUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED)
+        and, on completion, "download_url" or "error".
+    """
+    import boto3
+
+    client = boto3.client("athena")
+
+    try:
+        resp = client.get_query_execution(QueryExecutionId=query_id)
+    except Exception as e:
+        return {"state": "FAILED", "error": str(e)}
+
+    status = resp["QueryExecution"]["Status"]
+    query_state = status["State"]
+
+    if query_state == "SUCCEEDED":
+        location = resp["QueryExecution"].get("ResultConfiguration", {}).get("OutputLocation")
+        if not location:
+            return {
+                "state": "FAILED",
+                "error": "Query succeeded but has no recorded result location",
+            }
+        try:
+            bucket, key = _parse_s3_uri(location)
+        except ValueError as e:
+            return {"state": "FAILED", "error": str(e)}
+        s3 = boto3.client("s3")
+        download_url = s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=3600,
+        )
+        return {
+            "state": query_state,
+            "query_id": query_id,
+            "download_url": download_url,
+        }
+
+    if query_state in ("FAILED", "CANCELLED"):
+        reason = status.get("StateChangeReason", query_state)
+        return {"state": query_state, "error": reason}
+
+    return {"state": query_state}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/app.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/app.js
@@ -1,0 +1,66 @@
+// Initialization and top-level actions.
+// Depends on: core.js, tree.js, detail.js, components/registry.js
+
+async function loadRoot() {
+    const root = document.getElementById('treeRoot');
+    root.innerHTML = '<div class="tree-loading"><span class="spinner-inline"></span> Loading...</div>';
+
+    try {
+        const data = await fetchChildren('');
+        root.innerHTML = '';
+        renderChildren(data.children, '', 0, root);
+    } catch (err) {
+        root.innerHTML = '<div class="tree-loading" style="color:#dc3545;">Error loading tree.</div>';
+        console.error('loadRoot error:', err);
+    }
+}
+
+async function refresh() {
+    state.tree = {};
+    state.selectedPrefix = null;
+    state.stageInfo = {};
+
+    document.getElementById('treeRoot').innerHTML = '';
+    document.getElementById('detailPanel').innerHTML = '<div class="detail-empty">Select a node to inspect.</div>';
+
+    await fetchConfig();
+    await loadRoot();
+}
+
+async function initialize() {
+    try {
+        await fetchConfig();
+
+        // Restore user override from URL path before loading the tree
+        const urlPath = prefixFromUrl();
+        if (urlPath && state.config && state.config.environment === 'dev') {
+            const firstSlash = urlPath.indexOf('/');
+            if (firstSlash > 0) {
+                const maybeUser = urlPath.slice(0, firstSlash);
+                // Stage names contain underscores; user namespaces don't start with known stages
+                const KNOWN_STAGES = ['theme_promote', 'theme_stage', 'release_candidate'];
+                if (!KNOWN_STAGES.includes(maybeUser)) {
+                    state.user = maybeUser;
+                }
+            }
+        }
+
+        await loadUserSelector();
+        await loadRoot();
+
+        // Navigate to path from URL if present
+        if (urlPath) {
+            let prefix = urlPath;
+            if (state.user && prefix.startsWith(state.user + '/')) {
+                prefix = prefix.slice(state.user.length + 1);
+            }
+            if (prefix) await expandToPath(prefix);
+        }
+    } catch (err) {
+        console.error('initialize error:', err);
+        document.getElementById('treeRoot').innerHTML =
+            '<div class="tree-loading" style="color:#dc3545;">Failed to initialize. Reload the page.</div>';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', initialize);

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/athena-preview.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/athena-preview.js
@@ -1,0 +1,590 @@
+// Display component: Athena query editor with streaming CSV results and geometry map.
+// Depends on: core.js, csv-utils.js, map-utils.js, wkb.js (parseWkbHex, detectGeometryColumn,
+//             vertexAverage), components/registry.js, maplibre-gl
+
+const ATHENA_FOLDERS = new Set(['data', 'metrics', 'changelog', 'changelog_internal', 'bridgefiles', 'registry', 'validation']);
+const KNOWN_STAGES = new Set(['theme_promote', 'theme_stage', 'release_candidate']);
+const CHUNK_SIZE = 1024 * 1024; // 1 MB per Range request
+const MAX_MAP_FEATURES = 10000;
+
+let _codeJar;
+async function loadCodeJar() {
+    if (_codeJar) return _codeJar;
+    const mod = await import('https://cdn.jsdelivr.net/npm/codejar@4.2.0/dist/codejar.js');
+    _codeJar = mod.CodeJar;
+    return _codeJar;
+}
+
+function sanitizeIdentifier(s) {
+    return s.replace(/[^a-zA-Z0-9_]/g, '_').replace(/^_+|_+$/g, '') || 'segment';
+}
+
+function deriveAthenaTable(prefix) {
+    const parts = prefix.replace(/\/$/, '').split('/');
+
+    const stageIndex = parts.findIndex(p => KNOWN_STAGES.has(p));
+    if (stageIndex === -1) return null;
+    const stage = parts[stageIndex];
+    const rest = parts.slice(stageIndex + 1);
+
+    let folderIndex = -1;
+    for (let i = parts.length - 1; i >= 0; i--) {
+        if (ATHENA_FOLDERS.has(parts[i])) { folderIndex = i; break; }
+    }
+    if (folderIndex === -1) return null;
+    const folder = parts[folderIndex];
+
+    let run = null;
+    for (const part of rest) {
+        if (part.startsWith('run=')) { run = sanitizeIdentifier(part.split('=')[1]); break; }
+    }
+
+    // Inner theme= (after folder) is the fan-out root, not a data partition.
+    // Segments after the inner theme= are the actual partition columns (e.g. type=).
+    const afterFolder = parts.slice(folderIndex + 1);
+    const innerThemeIdx = afterFolder.findIndex(p => p.startsWith('theme='));
+    const innerTheme = innerThemeIdx >= 0 ? afterFolder[innerThemeIdx].split('=')[1] : null;
+
+    // Partition filters: Hive key=value segments after the table root.
+    const STRUCTURAL_KEYS = new Set(['run', 'schema', 'release']);
+    const tableRootEnd = innerThemeIdx >= 0
+        ? folderIndex + 2 + innerThemeIdx
+        : folderIndex + 1;
+    const partitionFilters = parts.slice(tableRootEnd)
+        .filter(p => p.includes('=') && !STRUCTURAL_KEYS.has(p.split('=')[0]))
+        .map(p => {
+            const eqIdx = p.indexOf('=');
+            const val = p.slice(eqIdx + 1).replace(/'/g, "''");
+            return `${p.slice(0, eqIdx)} = '${val}'`;
+        });
+
+    const nameParts = [stage];
+    if (stage === 'theme_promote') {
+        const restFolderIdx = folderIndex - stageIndex - 1;
+        const outerThemeSegment = rest.slice(0, restFolderIdx).find(p => p.startsWith('theme='));
+        const theme = outerThemeSegment ? outerThemeSegment.split('=')[1] : rest[0];
+        nameParts.push(theme);
+    } else if (stage === 'theme_stage') {
+        const dataset = rest[0] && !rest[0].includes('=') ? rest[0] : '';
+        if (dataset) nameParts.push(dataset);
+    }
+    if (run) nameParts.push(run);
+    if (innerTheme && folder === 'data') nameParts.push(innerTheme);
+    nameParts.push(folder);
+    const table = nameParts.map(sanitizeIdentifier).join('_');
+
+    return { table, partitionFilters };
+}
+
+function deriveAthenaDatabase() {
+    const cfg = state.config;
+    if (!cfg) return 'pipeline';
+    const ns = state.user || cfg.namespace;
+    if (cfg.environment === 'dev' && ns) return `${ns}_pipeline`;
+    return 'pipeline';
+}
+
+// Find the last safe line boundary in a chunk of CSV text.
+// "Safe" means all quotes are balanced up to that point, so we don't
+// split inside a quoted field that contains embedded newlines.
+function findSafeBreak(text) {
+    let inQuote = false;
+    let lastNewline = -1;
+    let i = 0;
+    while (i < text.length) {
+        const ch = text[i];
+        if (ch === '"') {
+            if (inQuote && i + 1 < text.length && text[i + 1] === '"') {
+                i += 2; // escaped double-quote inside quoted field
+                continue;
+            }
+            inQuote = !inQuote;
+        } else if (ch === '\r') {
+            if (!inQuote && i + 1 < text.length && text[i + 1] === '\n') {
+                lastNewline = i + 1;
+            }
+        } else if (ch === '\n' && !inQuote) {
+            lastNewline = i;
+        }
+        i++;
+    }
+    return lastNewline;
+}
+
+// Fetch a byte range from a URL. Returns {text, totalSize, bytesRead}.
+async function fetchChunk(url, start, size) {
+    const end = start + size - 1;
+    const res = await fetch(url, { headers: { 'Range': `bytes=${start}-${end}` } });
+    if (!res.ok && res.status !== 206) {
+        throw new Error(res.status === 403 ? 'URL expired, re-run query' : `Fetch failed: ${res.status}`);
+    }
+    const text = await res.text();
+    const contentRange = res.headers.get('Content-Range');
+    const contentLength = res.headers.get('Content-Length');
+    const bytesRead = contentLength ? parseInt(contentLength, 10) : new TextEncoder().encode(text).length;
+    const totalSize = contentRange ? parseInt(contentRange.split('/')[1], 10) : bytesRead;
+    return { text, totalSize, bytesRead };
+}
+
+function renderResultTable(container, columns, rows) {
+    const headerCells = columns.map(c => `<th>${escapeHtml(c)}</th>`).join('');
+    const bodyRows = rows.map(row =>
+        '<tr>' + row.map(val => `<td>${escapeHtml(val)}</td>`).join('') + '</tr>'
+    ).join('');
+
+    const wrap = document.createElement('div');
+    wrap.className = 'athena-table-wrap';
+    wrap.innerHTML = `
+        <table class="athena-table">
+            <thead><tr>${headerCells}</tr></thead>
+            <tbody>${bodyRows}</tbody>
+        </table>
+    `;
+    container.appendChild(wrap);
+    return wrap.querySelector('tbody');
+}
+
+function appendRows(tbody, rows) {
+    const fragment = document.createDocumentFragment();
+    for (const row of rows) {
+        const tr = document.createElement('tr');
+        for (const val of row) {
+            const td = document.createElement('td');
+            td.textContent = val;
+            tr.appendChild(td);
+        }
+        fragment.appendChild(tr);
+    }
+    tbody.appendChild(fragment);
+}
+
+function featurePopupHtml(properties) {
+    const rows = Object.entries(properties)
+        .map(([k, v]) => {
+            const val = typeof v === 'string' && v.length > 120 ? v.slice(0, 120) + '...' : v;
+            return `<tr><td style="font-weight:600;padding-right:8px;vertical-align:top;white-space:nowrap;">${escapeHtml(k)}</td><td>${escapeHtml(String(val))}</td></tr>`;
+        })
+        .join('');
+    return rows ? `<div style="max-height:300px;overflow:auto;font-size:12px;"><table>${rows}</table></div>` : '<em>No properties</em>';
+}
+
+function renderGeometryMap(container, dataFc, markerFc) {
+    const mapDiv = document.createElement('div');
+    mapDiv.className = 'component-map';
+    container.appendChild(mapDiv);
+
+    const bboxDiv = document.createElement('div');
+    bboxDiv.className = 'bbox-filter-hint';
+    container.appendChild(bboxDiv);
+
+    const map = new maplibregl.Map({
+        container: mapDiv,
+        style: CARTO_STYLE,
+        center: [0, 20],
+        zoom: 1,
+        minZoom: 0,
+        maxZoom: 22,
+    });
+
+    function updateBboxFilter() {
+        const b = map.getBounds();
+        const fmt = (n) => n.toFixed(4);
+        const text = `AND bbox.xmax >= ${fmt(b.getWest())} AND bbox.xmin <= ${fmt(b.getEast())} AND bbox.ymax >= ${fmt(b.getSouth())} AND bbox.ymin <= ${fmt(b.getNorth())}`;
+        bboxDiv.textContent = text;
+        bboxDiv.title = 'Click to copy';
+    }
+    map.on('moveend', updateBboxFilter);
+    bboxDiv.addEventListener('click', () => {
+        navigator.clipboard.writeText(bboxDiv.textContent);
+        bboxDiv.classList.add('copied');
+        setTimeout(() => bboxDiv.classList.remove('copied'), 1200);
+    });
+
+    map.on('load', () => {
+        map.addSource('athena-geom', { type: 'geojson', data: dataFc });
+        map.addSource('athena-markers', { type: 'geojson', data: markerFc });
+        map.addLayer({
+            id: 'athena-fill',
+            type: 'fill',
+            source: 'athena-geom',
+            minzoom: 0,
+            filter: ['==', '$type', 'Polygon'],
+            paint: { 'fill-color': '#4051CC', 'fill-opacity': 0.35 },
+        });
+        map.addLayer({
+            id: 'athena-outline',
+            type: 'line',
+            source: 'athena-geom',
+            minzoom: 0,
+            filter: ['==', '$type', 'Polygon'],
+            paint: { 'line-color': '#4051CC', 'line-width': 1.5 },
+        });
+        map.addLayer({
+            id: 'athena-line',
+            type: 'line',
+            source: 'athena-geom',
+            minzoom: 0,
+            filter: ['==', '$type', 'LineString'],
+            paint: { 'line-color': '#4051CC', 'line-width': 2 },
+        });
+        map.addLayer({
+            id: 'athena-point',
+            type: 'circle',
+            source: 'athena-geom',
+            minzoom: 0,
+            filter: ['==', '$type', 'Point'],
+            paint: { 'circle-color': '#4051CC', 'circle-radius': 5, 'circle-opacity': 0.8 },
+        });
+        map.addLayer({
+            id: 'athena-marker',
+            type: 'circle',
+            source: 'athena-markers',
+            minzoom: 0,
+            maxzoom: 14,
+            paint: { 'circle-color': '#4051CC', 'circle-radius': 5, 'circle-opacity': 0.8 },
+        });
+
+        const interactiveLayers = ['athena-fill', 'athena-outline', 'athena-line', 'athena-point', 'athena-marker'];
+        map.on('mousemove', (e) => {
+            const features = map.queryRenderedFeatures(e.point, { layers: interactiveLayers });
+            map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+        });
+        map.on('click', (e) => {
+            const features = map.queryRenderedFeatures(e.point, { layers: interactiveLayers });
+            if (!features.length) return;
+            new maplibregl.Popup({ maxWidth: '400px' })
+                .setLngLat(e.lngLat)
+                .setHTML(featurePopupHtml(features[0].properties || {}))
+                .addTo(map);
+        });
+
+        fitMapToFeatures(map, dataFc.features);
+        updateBboxFilter();
+    });
+
+    return map;
+}
+
+async function renderAthenaPreview(container, prefix) {
+    const info = deriveAthenaTable(prefix);
+    const database = deriveAthenaDatabase();
+
+    if (!info) {
+        const msg = document.createElement('div');
+        msg.style.cssText = 'color:#6c757d;margin-top:16px;';
+        msg.textContent = 'Could not derive Athena table name from path.';
+        container.appendChild(msg);
+        return () => {};
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'athena-preview';
+    container.appendChild(wrapper);
+
+    const title = document.createElement('div');
+    title.className = 'detail-section-title';
+    title.style.marginTop = '24px';
+    title.textContent = 'Athena Query';
+    wrapper.appendChild(title);
+
+    const editorRow = document.createElement('div');
+    editorRow.className = 'athena-editor';
+    wrapper.appendChild(editorRow);
+
+    const partitionFilters = info.partitionFilters || [];
+    const typeFilter = partitionFilters.length > 0 ? `\nWHERE ${partitionFilters.join('\n  AND ')}` : '';
+    const defaultSql = `SELECT * FROM "${database}"."${info.table}"${typeFilter}\nLIMIT 10`;
+    let getSql, editorCleanup = () => {};
+
+    function onEditorKey(e) {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault();
+            runQuery();
+        }
+    }
+
+    try {
+        const CodeJar = await loadCodeJar();
+        const editorEl = document.createElement('div');
+        editorEl.className = 'athena-sql language-sql';
+        editorEl.textContent = defaultSql;
+        editorRow.appendChild(editorEl);
+        const highlight = (el) => Prism.highlightElement(el);
+        const jar = CodeJar(editorEl, highlight, { tab: '  ' });
+        jar.updateCode(jar.toString());
+        getSql = () => jar.toString().trim();
+        editorCleanup = () => jar.destroy();
+        editorEl.addEventListener('keydown', onEditorKey);
+    } catch (err) {
+        console.warn('CodeJar load failed, using textarea fallback', err);
+        const textarea = document.createElement('textarea');
+        textarea.className = 'athena-sql';
+        textarea.rows = 3;
+        textarea.value = defaultSql;
+        editorRow.appendChild(textarea);
+        getSql = () => textarea.value.trim();
+        textarea.addEventListener('keydown', onEditorKey);
+    }
+
+    const btnRow = document.createElement('div');
+    btnRow.className = 'athena-controls';
+    wrapper.appendChild(btnRow);
+
+    const runBtn = document.createElement('button');
+    runBtn.className = 'btn btn-primary';
+    runBtn.textContent = 'Run';
+    btnRow.appendChild(runBtn);
+
+    const statusSpan = document.createElement('span');
+    statusSpan.className = 'athena-status';
+    btnRow.appendChild(statusSpan);
+
+    const mapArea = document.createElement('div');
+    wrapper.appendChild(mapArea);
+
+    const resultsDiv = document.createElement('div');
+    resultsDiv.className = 'athena-results';
+    wrapper.appendChild(resultsDiv);
+
+    const statusBar = document.createElement('div');
+    statusBar.className = 'athena-status-bar';
+    wrapper.appendChild(statusBar);
+
+    // Mutable query state
+    let currentMap = null;
+    let downloadUrl = null;  // presigned URL for download link (navigation, no CORS)
+    let csvProxyUrl = null;  // proxied URL for Range fetches (avoids CORS)
+    let columns = null;
+    let allRows = [];
+    let parsedFeatures = []; // cached GeoJSON features to avoid re-decoding WKB
+    let remainder = '';
+    let bytesLoaded = 0;
+    let totalSize = 0;
+    let geomCol = -1;
+    let tbody = null;
+
+    function updateStatusBar() {
+        const loaded = formatSize(bytesLoaded);
+        const total = formatSize(totalSize);
+        const hasMore = bytesLoaded < totalSize;
+
+        let html = `${allRows.length} row${allRows.length !== 1 ? 's' : ''} (${loaded} of ${total})`;
+        if (geomCol >= 0 && allRows.length > MAX_MAP_FEATURES) {
+            html += ` &middot; map shows first ${MAX_MAP_FEATURES.toLocaleString()} features`;
+        }
+        if (downloadUrl) {
+            html += ` <a href="${escapeHtml(downloadUrl)}" target="_blank" rel="noopener" class="athena-download">Download full CSV</a>`;
+        }
+        statusBar.innerHTML = html;
+
+        // Load more button
+        const existingBtn = statusBar.querySelector('.athena-load-more');
+        if (existingBtn) existingBtn.remove();
+        if (hasMore) {
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-secondary athena-load-more';
+            btn.textContent = 'Load more';
+            btn.addEventListener('click', loadMore);
+            statusBar.appendChild(btn);
+        }
+    }
+
+    function updateMap() {
+        if (geomCol < 0) return;
+        // Parse only newly added rows since last update
+        const propIndices = columns.map((col, i) => [col, i]).filter(([_, i]) => i !== geomCol);
+        while (parsedFeatures.length < allRows.length && parsedFeatures.length < MAX_MAP_FEATURES) {
+            const row = allRows[parsedFeatures.length];
+            const geometry = parseWkbHex(row[geomCol]);
+            if (!geometry) { parsedFeatures.push(null); continue; }
+            const properties = {};
+            for (const [col, idx] of propIndices) properties[col] = row[idx];
+            const feature = { type: 'Feature', geometry, properties };
+            parsedFeatures.push(feature);
+        }
+        const features = parsedFeatures.filter(f => f !== null);
+        // Add vertex-average markers for non-point features
+        const markers = features
+            .filter(f => f.geometry.type !== 'Point')
+            .map(f => ({
+                type: 'Feature',
+                properties: { ...f.properties, _marker: true },
+                geometry: { type: 'Point', coordinates: vertexAverage(f.geometry) },
+            }));
+        const dataFc = { type: 'FeatureCollection', features };
+        const markerFc = { type: 'FeatureCollection', features: markers };
+        if (currentMap) {
+            const src = currentMap.getSource('athena-geom');
+            if (src) {
+                src.setData(dataFc);
+                currentMap.getSource('athena-markers').setData(markerFc);
+                return;
+            }
+        }
+        currentMap = renderGeometryMap(mapArea, dataFc, markerFc);
+    }
+
+    async function loadMore() {
+        if (bytesLoaded >= totalSize) return;
+        const loadBtn = statusBar.querySelector('.athena-load-more');
+        if (loadBtn) { loadBtn.disabled = true; loadBtn.textContent = 'Loading...'; }
+
+        try {
+            const chunk = await fetchChunk(csvProxyUrl, bytesLoaded, CHUNK_SIZE);
+            const text = remainder + chunk.text;
+            const breakIdx = findSafeBreak(text);
+
+            if (breakIdx === -1) {
+                // Entire chunk is one incomplete line -- accumulate and try again
+                remainder = text;
+                bytesLoaded += chunk.bytesRead;
+            } else {
+                const complete = text.slice(0, breakIdx + 1);
+                remainder = text.slice(breakIdx + 1);
+                bytesLoaded += chunk.bytesRead;
+                if (bytesLoaded > totalSize) bytesLoaded = totalSize;
+
+                const newRows = splitCsvLines(complete);
+                allRows = allRows.concat(newRows);
+                appendRows(tbody, newRows);
+                updateMap();
+            }
+
+            updateStatusBar();
+        } catch (err) {
+            statusBar.innerHTML = `<span style="color:#dc3545;">${escapeHtml(String(err))}</span>`;
+        }
+    }
+
+    async function runQuery() {
+        const sql = getSql();
+        if (!sql) return;
+
+        runBtn.disabled = true;
+        statusSpan.innerHTML = '<span class="spinner-inline"></span> Running...';
+        resultsDiv.innerHTML = '';
+        mapArea.innerHTML = '';
+        statusBar.innerHTML = '';
+        if (currentMap) { currentMap.remove(); currentMap = null; }
+        allRows = [];
+        parsedFeatures = [];
+        remainder = '';
+        bytesLoaded = 0;
+        totalSize = 0;
+        geomCol = -1;
+        columns = null;
+        csvProxyUrl = null;
+        tbody = null;
+
+        // Phase 1: start query, poll until Athena finishes
+        let data;
+        try {
+            data = await fetchAthenaQuery(sql, (athenaState) => {
+                const label = athenaState === 'RUNNING' ? 'Running' : athenaState === 'QUEUED' ? 'Queued' : athenaState;
+                statusSpan.innerHTML = `<span class="spinner-inline"></span> ${label}...`;
+            });
+        } catch (err) {
+            runBtn.disabled = false;
+            statusSpan.textContent = '';
+            resultsDiv.innerHTML = `<div class="athena-error">${escapeHtml(String(err))}</div>`;
+            return;
+        }
+
+        runBtn.disabled = false;
+        statusSpan.textContent = '';
+
+        if (data.error) {
+            resultsDiv.innerHTML = `<div class="athena-error">${escapeHtml(data.error)}</div>`;
+            return;
+        }
+
+        downloadUrl = data.download_url;
+        const queryId = data.query_id;
+        if (!queryId) {
+            resultsDiv.innerHTML = '<div class="athena-error">No query ID returned.</div>';
+            return;
+        }
+
+        // Build proxy URL for Range fetches (avoids CORS on S3 presigned URLs)
+        const proxyBase = `${API_BASE}/athena-csv?query_id=${encodeURIComponent(queryId)}`;
+        csvProxyUrl = `${proxyBase}${userParam(proxyBase)}`;
+
+        // Phase 2: stream first CSV chunk via proxy
+        statusSpan.innerHTML = '<span class="spinner-inline"></span> Fetching results...';
+
+        let chunk;
+        try {
+            chunk = await fetchChunk(csvProxyUrl, 0, CHUNK_SIZE);
+        } catch (err) {
+            statusSpan.textContent = '';
+            resultsDiv.innerHTML = `<div class="athena-error">${escapeHtml(String(err))}</div>`;
+            return;
+        }
+
+        statusSpan.textContent = '';
+        totalSize = chunk.totalSize;
+
+        const text = chunk.text;
+        const breakIdx = findSafeBreak(text);
+
+        let complete;
+        if (breakIdx === -1) {
+            // Entire chunk is one logical line (or file is small enough)
+            complete = text;
+            remainder = '';
+            bytesLoaded = chunk.bytesRead;
+        } else {
+            complete = text.slice(0, breakIdx + 1);
+            remainder = text.slice(breakIdx + 1);
+            bytesLoaded = chunk.bytesRead;
+        }
+        if (bytesLoaded >= totalSize) {
+            bytesLoaded = totalSize;
+            remainder = '';
+            // If the whole file fits in one chunk, use all the text
+            complete = text;
+        }
+
+        const parsed = splitCsvLines(complete);
+        if (parsed.length === 0) {
+            resultsDiv.innerHTML = '<div style="color:#6c757d;">No results.</div>';
+            return;
+        }
+
+        columns = parsed[0];
+        allRows = parsed.slice(1);
+
+        if (columns.length === 0) {
+            resultsDiv.innerHTML = '<div style="color:#6c757d;">No results.</div>';
+            return;
+        }
+
+        // Phase 3: render table
+        tbody = renderResultTable(resultsDiv, columns, allRows);
+
+        // Phase 4: detect geometry and render map
+        // Scan up to 50 rows in case early rows have null geometry
+        const scanLimit = Math.min(allRows.length, 50);
+        for (let i = 0; i < scanLimit && geomCol < 0; i++) {
+            geomCol = detectGeometryColumn(columns, allRows[i]);
+        }
+        if (geomCol >= 0) updateMap();
+
+        updateStatusBar();
+    }
+
+    runBtn.addEventListener('click', runQuery);
+
+    return () => {
+        editorCleanup();
+        if (currentMap) currentMap.remove();
+    };
+}
+
+registerComponent('data', { render: renderAthenaPreview });
+registerComponent('metrics', { render: renderAthenaPreview });
+registerComponent('changelog', { render: renderAthenaPreview });
+registerComponent('changelog_internal', { render: renderAthenaPreview });
+registerComponent('bridgefiles', { render: renderAthenaPreview });
+registerComponent('registry', { render: renderAthenaPreview });
+registerComponent('validation', { render: renderAthenaPreview });

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/bbox-map.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/bbox-map.js
@@ -1,0 +1,56 @@
+// Display component: partition bounding boxes on a map.
+// Depends on: core.js, map-utils.js (CARTO_STYLE, fitMapToFeatures), components/registry.js, maplibre-gl
+
+async function renderBboxMap(container, prefix) {
+    const mapDiv = document.createElement('div');
+    mapDiv.className = 'component-map';
+    container.appendChild(mapDiv);
+
+    const loading = document.createElement('div');
+    loading.style.cssText = 'color:#6c757d;margin-top:8px;';
+    loading.innerHTML = '<span class="spinner-inline"></span> Loading parquet data...';
+    container.appendChild(loading);
+
+    const dataUrl = `${API_BASE}/component-data?prefix=${encodeURIComponent(prefix)}`;
+    const res = await fetch(`${dataUrl}${userParam(dataUrl)}`);
+    if (!res.ok) {
+        loading.innerHTML = '<span style="color:#dc3545;">Error loading data.</span>';
+        return () => {};
+    }
+    const geojson = await res.json();
+    loading.remove();
+
+    const map = new maplibregl.Map({
+        container: mapDiv,
+        style: CARTO_STYLE,
+        center: [0, 20],
+        zoom: 1,
+    });
+
+    map.on('load', () => {
+        map.addSource('bboxes', { type: 'geojson', data: geojson });
+        map.addLayer({
+            id: 'bbox-fill',
+            type: 'fill',
+            source: 'bboxes',
+            paint: { 'fill-color': '#4051CC', 'fill-opacity': 0.12 },
+        });
+        map.addLayer({
+            id: 'bbox-outline',
+            type: 'line',
+            source: 'bboxes',
+            paint: { 'line-color': '#4051CC', 'line-width': 1 },
+        });
+
+        fitMapToFeatures(map, geojson.features);
+    });
+
+    const info = document.createElement('div');
+    info.style.cssText = 'margin-top:8px;font-size:0.85em;color:#6c757d;';
+    info.textContent = `${geojson.features.length} partition bboxes`;
+    container.appendChild(info);
+
+    return () => map.remove();
+}
+
+registerComponent('partition_bboxes', { render: renderBboxMap });

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/csv-viewer.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/csv-viewer.js
@@ -1,0 +1,87 @@
+// Display component: CSV file viewer.
+// Lists .csv files under a prefix, fetches each via s3proxy, and renders as tables.
+// Depends on: core.js (fetchChildren, escapeHtml, userParam, API_BASE),
+//             csv-utils.js (splitCsvRow, parseCsv), components/registry.js
+
+async function fetchCsvText(key) {
+    const url = `${API_BASE}/s3proxy?key=${encodeURIComponent(key)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`Failed to fetch CSV: ${res.status}`);
+    return await res.text();
+}
+
+function renderCsvTable(container, title, csv) {
+    const heading = document.createElement('div');
+    heading.className = 'detail-section-title';
+    heading.style.marginTop = '16px';
+    heading.textContent = title;
+    container.appendChild(heading);
+
+    if (csv.columns.length === 0) {
+        const msg = document.createElement('div');
+        msg.style.color = '#6c757d';
+        msg.textContent = 'Empty CSV.';
+        container.appendChild(msg);
+        return;
+    }
+
+    const headerCells = csv.columns.map(c =>
+        `<th>${escapeHtml(c)}</th>`
+    ).join('');
+
+    const bodyRows = csv.rows.map(row =>
+        '<tr>' + row.map(val =>
+            `<td>${escapeHtml(val)}</td>`
+        ).join('') + '</tr>'
+    ).join('');
+
+    const wrap = document.createElement('div');
+    wrap.className = 'athena-table-wrap';
+    wrap.innerHTML = `
+        <table class="athena-table">
+            <thead><tr>${headerCells}</tr></thead>
+            <tbody>${bodyRows}</tbody>
+        </table>
+    `;
+    container.appendChild(wrap);
+}
+
+async function renderCsvViewer(container, prefix) {
+    const data = await fetchChildren(prefix);
+    const csvFiles = (data.children || [])
+        .filter(c => c.type === 'file' && c.name.endsWith('.csv'))
+        .map(c => c.name);
+
+    if (csvFiles.length === 0) {
+        const msg = document.createElement('div');
+        msg.style.cssText = 'color:#6c757d;margin-top:16px;';
+        msg.textContent = 'No CSV files found.';
+        container.appendChild(msg);
+        return () => {};
+    }
+
+    const results = await Promise.all(csvFiles.map(async filename => {
+        const key = prefix + filename;
+        try {
+            const text = await fetchCsvText(key);
+            return { filename, csv: parseCsv(text) };
+        } catch (err) {
+            return { filename, error: err.message };
+        }
+    }));
+
+    for (const r of results) {
+        if (r.error) {
+            const errDiv = document.createElement('div');
+            errDiv.style.color = '#dc3545';
+            errDiv.textContent = `Error loading ${r.filename}: ${r.error}`;
+            container.appendChild(errDiv);
+        } else {
+            renderCsvTable(container, r.filename.replace(/\.csv$/, ''), r.csv);
+        }
+    }
+
+    return () => {};
+}
+
+registerComponent('metrics_summary', { render: renderCsvViewer });

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/folder-tree.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/folder-tree.js
@@ -1,0 +1,80 @@
+// Display component: abridged folder tree for any bundle component.
+// Depends on: core.js (fetchTree, escapeHtml, formatSize), components/registry.js
+
+async function renderFolderTree(container, prefix) {
+    const loading = document.createElement('div');
+    loading.style.cssText = 'color:#6c757d;margin-top:16px;';
+    loading.innerHTML = '<span class="spinner-inline"></span> Loading folder structure...';
+    container.appendChild(loading);
+
+    let tree;
+    try {
+        tree = await fetchTree(prefix);
+    } catch (err) {
+        loading.innerHTML = '<span style="color:#dc3545;">Error loading tree.</span>';
+        console.error('folder-tree error:', err);
+        return () => {};
+    }
+
+    loading.remove();
+
+    const title = document.createElement('div');
+    title.className = 'detail-section-title';
+    title.style.marginTop = '24px';
+    title.textContent = 'Folder Structure';
+    container.appendChild(title);
+
+    if (tree._total_keys === 0) {
+        const empty = document.createElement('div');
+        empty.style.color = '#6c757d';
+        empty.textContent = 'Empty directory.';
+        container.appendChild(empty);
+        return () => {};
+    }
+
+    const info = document.createElement('div');
+    info.style.cssText = 'color:#6c757d;font-size:0.85em;margin-bottom:8px;';
+    let infoText = `${tree._total_keys.toLocaleString()} objects`;
+    if (tree._truncated) infoText += ' (listing truncated)';
+    info.textContent = infoText;
+    container.appendChild(info);
+
+    const pre = document.createElement('pre');
+    pre.className = 'folder-tree';
+    container.appendChild(pre);
+
+    const lines = [];
+    renderTreeNode(lines, tree, '', true);
+    pre.textContent = lines.join('\n');
+
+    return () => {};
+}
+
+function renderTreeNode(lines, node, indent, isRoot) {
+    const dirNames = Object.keys(node.dirs).sort();
+    const files = node.files || [];
+    const omitted = node._omitted || 0;
+
+    for (let i = 0; i < dirNames.length; i++) {
+        const name = dirNames[i];
+        const isLast = i === dirNames.length - 1 && files.length === 0 && omitted === 0;
+        const connector = isRoot ? '' : (isLast ? '\u2514\u2500 ' : '\u251c\u2500 ');
+        const childIndent = isRoot ? '' : (indent + (isLast ? '   ' : '\u2502  '));
+        lines.push(`${indent}${connector}${name}/`);
+        renderTreeNode(lines, node.dirs[name], childIndent, false);
+    }
+
+    for (let i = 0; i < files.length; i++) {
+        const isLast = i === files.length - 1 && omitted === 0;
+        const connector = isRoot ? '' : (isLast ? '\u2514\u2500 ' : '\u251c\u2500 ');
+        lines.push(`${indent}${connector}${files[i]}`);
+    }
+
+    if (omitted > 0) {
+        const connector = isRoot ? '' : '\u2514\u2500 ';
+        lines.push(`${indent}${connector}... ${omitted} more file${omitted !== 1 ? 's' : ''}`);
+    }
+}
+
+// No explicit registration -- renderFolderTree is used as the fallback
+// in renderComponentContent when no other components match.

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/markdown-viewer.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/markdown-viewer.js
@@ -1,0 +1,55 @@
+// Display component: markdown file viewer.
+// Fetches .md files via s3proxy and renders them as HTML using marked.
+// Depends on: core.js (API_BASE, userParam, escapeHtml), marked (CDN)
+
+// Escape raw HTML in markdown source to prevent XSS.
+marked.use({
+    renderer: {
+        html(token) { return escapeHtml(token.raw); },
+    }
+});
+
+async function fetchMarkdownText(key) {
+    const url = `${API_BASE}/s3proxy?key=${encodeURIComponent(key)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`Failed to fetch markdown: ${res.status}`);
+    return await res.text();
+}
+
+async function renderMarkdownFiles(container, prefix, mdFiles) {
+    if (mdFiles.length === 0) return;
+
+    const results = await Promise.all(mdFiles.map(async f => {
+        const key = prefix + f.name;
+        try {
+            const text = await fetchMarkdownText(key);
+            return { filename: f.name, text };
+        } catch (err) {
+            return { filename: f.name, error: err.message };
+        }
+    }));
+
+    for (const r of results) {
+        const section = document.createElement('div');
+        section.className = 'markdown-section';
+
+        const heading = document.createElement('div');
+        heading.className = 'detail-section-title';
+        heading.textContent = r.filename;
+        section.appendChild(heading);
+
+        if (r.error) {
+            const errDiv = document.createElement('div');
+            errDiv.style.color = '#dc3545';
+            errDiv.textContent = `Error loading ${r.filename}: ${r.error}`;
+            section.appendChild(errDiv);
+        } else {
+            const body = document.createElement('div');
+            body.className = 'markdown-body';
+            body.innerHTML = marked.parse(r.text);
+            section.appendChild(body);
+        }
+
+        container.appendChild(section);
+    }
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/parquet-stats.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/parquet-stats.js
@@ -1,0 +1,63 @@
+// Display component: parquet file stats and schema.
+// Depends on: core.js (formatSize, fetchParquetStats, escapeHtml), components/registry.js
+
+async function renderParquetStats(container, prefix) {
+    const loading = document.createElement('div');
+    loading.style.cssText = 'color:#6c757d;margin-top:8px;';
+    loading.innerHTML = '<span class="spinner-inline"></span> Loading parquet stats...';
+    container.appendChild(loading);
+
+    let stats;
+    try {
+        stats = await fetchParquetStats(prefix);
+    } catch (err) {
+        loading.innerHTML = '<span style="color:#dc3545;">Error loading stats.</span>';
+        console.error('parquet-stats error:', err);
+        return () => {};
+    }
+
+    loading.remove();
+
+    if (stats.file_count === 0) {
+        container.innerHTML = '<span style="color:#6c757d;">No parquet files found.</span>';
+        return () => {};
+    }
+
+    const statsHtml = `
+        <table class="parquet-stats-table">
+            <tr><td>Files</td><td>${stats.file_count.toLocaleString()}</td></tr>
+            <tr><td>Total size</td><td>${formatSize(stats.total_size)}</td></tr>
+            <tr><td>Avg size</td><td>${formatSize(stats.avg_size)}</td></tr>
+            <tr><td>Min size</td><td>${formatSize(stats.min_size)}</td></tr>
+            <tr><td>Max size</td><td>${formatSize(stats.max_size)}</td></tr>
+        </table>
+    `;
+
+    let schemaHtml = '';
+    if (stats.schema && stats.schema.length > 0) {
+        const rows = stats.schema.map(f =>
+            `<tr><td>${escapeHtml(f.name)}</td><td>${escapeHtml(f.type)}</td></tr>`
+        ).join('');
+        schemaHtml = `
+            <div class="detail-section-title" style="margin-top:16px;">Schema</div>
+            <table class="parquet-schema-table">
+                <thead><tr><th>Column</th><th>Type</th></tr></thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = statsHtml + schemaHtml;
+    container.appendChild(wrapper);
+
+    return () => {};
+}
+
+registerComponent('data', { render: renderParquetStats });
+registerComponent('metrics', { render: renderParquetStats });
+registerComponent('changelog', { render: renderParquetStats });
+registerComponent('changelog_internal', { render: renderParquetStats });
+registerComponent('bridgefiles', { render: renderParquetStats });
+registerComponent('registry', { render: renderParquetStats });
+registerComponent('validation', { render: renderParquetStats });

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/pmtiles-viewer.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/pmtiles-viewer.js
@@ -1,0 +1,234 @@
+// Display component: PMTiles vector tile viewer.
+// Range requests are proxied through Airflow (/s3proxy) to avoid S3 CORS issues.
+// Depends on: core.js, map-utils.js (CARTO_STYLE), components/registry.js, maplibre-gl
+
+let pmtilesReady = null;
+
+function ensurePmtiles() {
+    if (pmtilesReady) return pmtilesReady;
+    pmtilesReady = import('https://cdn.jsdelivr.net/npm/pmtiles@4.4.0/+esm')
+        .then(mod => {
+            const protocol = new mod.Protocol();
+            maplibregl.addProtocol('pmtiles', protocol.tile);
+            return mod;
+        })
+        .catch(err => {
+            pmtilesReady = null;  // allow retry on next call
+            throw err;
+        });
+    return pmtilesReady;
+}
+
+function proxyUrl(key) {
+    const url = `${location.origin}${API_BASE}/s3proxy?key=${encodeURIComponent(key)}`;
+    return `${url}${userParam(url)}`;
+}
+
+async function loadPmtilesMap(mapContainer, key) {
+    const url = proxyUrl(key);
+
+    const pmtiles = await ensurePmtiles();
+    const pm = new pmtiles.PMTiles(url);
+    const header = await pm.getHeader();
+    const metadata = await pm.getMetadata();
+
+    const layers = (metadata.vector_layers || []).map(l => l.id);
+    const layersToUse = layers.length > 0 ? layers : ['default'];
+
+    const map = new maplibregl.Map({
+        container: mapContainer,
+        style: CARTO_STYLE,
+        center: [
+            (header.minLon + header.maxLon) / 2,
+            (header.minLat + header.maxLat) / 2,
+        ],
+        zoom: 1,
+    });
+
+    map.on('load', () => {
+        map.addSource('pmtiles', {
+            type: 'vector',
+            url: `pmtiles://${url}`,
+        });
+
+        for (const layer of layersToUse) {
+            map.addLayer({
+                id: `pm-fill-${layer}`,
+                type: 'fill',
+                source: 'pmtiles',
+                'source-layer': layer,
+                filter: ['==', '$type', 'Polygon'],
+                paint: { 'fill-color': '#4051CC', 'fill-opacity': 0.15 },
+            });
+            map.addLayer({
+                id: `pm-line-${layer}`,
+                type: 'line',
+                source: 'pmtiles',
+                'source-layer': layer,
+                filter: ['==', '$type', 'LineString'],
+                paint: { 'line-color': '#4051CC', 'line-width': 1 },
+            });
+            map.addLayer({
+                id: `pm-point-${layer}`,
+                type: 'circle',
+                source: 'pmtiles',
+                'source-layer': layer,
+                filter: ['==', '$type', 'Point'],
+                paint: {
+                    'circle-color': '#4051CC',
+                    'circle-radius': 2.5,
+                    'circle-opacity': 0.6,
+                },
+            });
+        }
+
+        // Collect all interactive layer IDs for hover/click queries
+        const interactiveLayers = layersToUse.flatMap(layer => [
+            `pm-fill-${layer}`, `pm-line-${layer}`, `pm-point-${layer}`,
+        ]);
+
+        // Hover: highlight feature under cursor
+        map.on('mousemove', (e) => {
+            const features = map.queryRenderedFeatures(e.point, { layers: interactiveLayers });
+            map.getCanvas().style.cursor = features.length ? 'pointer' : '';
+
+            // Update hover paint for fills
+            for (const layer of layersToUse) {
+                map.setPaintProperty(`pm-fill-${layer}`, 'fill-opacity',
+                    features.length > 0
+                        ? ['case', ['==', ['id'], features[0].id ?? -1], 0.45, 0.15]
+                        : 0.15
+                );
+            }
+        });
+        map.getCanvas().addEventListener('mouseleave', () => {
+            map.getCanvas().style.cursor = '';
+        });
+
+        // Click: show all overlapping features in a popup
+        map.on('click', (e) => {
+            const features = map.queryRenderedFeatures(e.point, { layers: interactiveLayers });
+            if (!features.length) return;
+
+            function featureTable(props) {
+                const rows = Object.entries(props)
+                    .map(([k, v]) => {
+                        const val = typeof v === 'string' && v.length > 120
+                            ? v.slice(0, 120) + '...' : v;
+                        return `<tr><td style="font-weight:600;padding-right:8px;vertical-align:top;white-space:nowrap;">${escapeHtml(k)}</td><td>${escapeHtml(String(val))}</td></tr>`;
+                    })
+                    .join('');
+                return rows ? `<table>${rows}</table>` : '<em>No properties</em>';
+            }
+
+            const sections = features.map((feat, i) => {
+                const label = feat.sourceLayer || `Feature ${i + 1}`;
+                const header = features.length > 1
+                    ? `<div style="font-weight:700;font-size:11px;color:#4051CC;margin:${i > 0 ? '10px' : '0'} 0 4px;border-top:${i > 0 ? '1px solid #e0e0e0;padding-top:8px;' : 'none'}">${escapeHtml(label)} (${i + 1}/${features.length})</div>`
+                    : '';
+                return header + featureTable(feat.properties || {});
+            }).join('');
+
+            const html = `<div style="max-height:300px;overflow:auto;font-size:12px;">${sections}</div>`;
+
+            new maplibregl.Popup({ maxWidth: '400px' })
+                .setLngLat(e.lngLat)
+                .setHTML(html)
+                .addTo(map);
+        });
+
+        if (header.minLon !== 0 || header.maxLon !== 0) {
+            map.fitBounds(
+                [[header.minLon, header.minLat], [header.maxLon, header.maxLat]],
+                { padding: 40 }
+            );
+        }
+    });
+
+    const zoomRange = `z${header.minZoom}-${header.maxZoom}`;
+    const infoText = layers.length > 0
+        ? `${layers.join(', ')} (${zoomRange})`
+        : `PMTiles (${zoomRange})`;
+
+    return { map, infoText };
+}
+
+async function renderPmtilesViewer(container, prefix) {
+    // List children to discover .pmtiles files
+    const data = await fetchChildren(prefix);
+    const pmtilesFiles = (data.children || [])
+        .filter(c => c.type === 'file' && c.name.endsWith('.pmtiles'))
+        .map(c => c.name);
+
+    if (pmtilesFiles.length === 0) {
+        container.innerHTML = '<span style="color:#dc3545;">No .pmtiles files found.</span>';
+        return () => {};
+    }
+
+    let currentMap = null;
+
+    async function showFile(filename) {
+        if (currentMap) { currentMap.remove(); currentMap = null; }
+
+        // Clear any previous map/info from the render area
+        renderArea.innerHTML = '';
+
+        const mapDiv = document.createElement('div');
+        mapDiv.className = 'component-map';
+        renderArea.appendChild(mapDiv);
+
+        const loading = document.createElement('div');
+        loading.style.cssText = 'color:#6c757d;margin-top:8px;';
+        loading.innerHTML = '<span class="spinner-inline"></span> Loading PMTiles header...';
+        renderArea.appendChild(loading);
+
+        // Build the S3 key relative to namespace
+        const key = prefix + filename;
+
+        try {
+            const result = await loadPmtilesMap(mapDiv, key);
+            currentMap = result.map;
+            loading.remove();
+
+            const info = document.createElement('div');
+            info.style.cssText = 'margin-top:8px;font-size:0.85em;color:#6c757d;';
+            info.textContent = result.infoText;
+            renderArea.appendChild(info);
+        } catch (err) {
+            loading.innerHTML = `<span style="color:#dc3545;">Error loading PMTiles: ${escapeHtml(err.message)}</span>`;
+            console.error('loadPmtilesMap error:', err);
+        }
+    }
+
+    // Render area for the map (below selector if present)
+    const renderArea = document.createElement('div');
+
+    // Show file selector if multiple .pmtiles files
+    if (pmtilesFiles.length > 1) {
+        const selectorDiv = document.createElement('div');
+        selectorDiv.className = 'theme-type-selector';
+
+        const label = document.createElement('label');
+        label.textContent = 'Theme';
+
+        const select = document.createElement('select');
+        for (const f of pmtilesFiles) {
+            const opt = document.createElement('option');
+            opt.value = f;
+            opt.textContent = f.replace(/\.pmtiles$/, '');
+            select.appendChild(opt);
+        }
+        select.addEventListener('change', () => showFile(select.value));
+
+        selectorDiv.appendChild(label);
+        selectorDiv.appendChild(select);
+        container.appendChild(selectorDiv);
+    }
+
+    container.appendChild(renderArea);
+    await showFile(pmtilesFiles[0]);
+
+    return () => { if (currentMap) currentMap.remove(); };
+}
+
+registerComponent('pmtiles', { render: renderPmtilesViewer });

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/registry.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/components/registry.js
@@ -1,0 +1,152 @@
+// Display component registry.
+// Each component file calls registerComponent() to self-register.
+// Multiple components can register for the same name; they render stacked.
+// Depends on: core.js
+
+const DISPLAY_COMPONENTS = {};
+let activeCleanups = [];
+
+function registerComponent(name, component) {
+    if (!DISPLAY_COMPONENTS[name]) {
+        DISPLAY_COMPONENTS[name] = [];
+    }
+    DISPLAY_COMPONENTS[name].push(component);
+}
+
+function componentNameFromPrefix(prefix) {
+    const parts = prefix.replace(/\/$/, '').split('/');
+    return parts[parts.length - 1];
+}
+
+async function renderComponentContent(contentDiv, prefix, componentName) {
+    const displays = DISPLAY_COMPONENTS[componentName];
+
+    if (displays && displays.length > 0) {
+        for (const display of displays) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'component-section';
+            contentDiv.appendChild(wrapper);
+            const cleanup = await display.render(wrapper, prefix);
+            if (cleanup) activeCleanups.push(cleanup);
+        }
+    } else {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'component-section';
+        contentDiv.appendChild(wrapper);
+        const cleanup = await renderFolderTree(wrapper, prefix);
+        if (cleanup) activeCleanups.push(cleanup);
+    }
+}
+
+function buildNarrowedPrefix(basePrefix, themeDir, typeDir) {
+    let p = basePrefix;
+    if (themeDir) p += `${themeDir}/`;
+    if (typeDir) p += `${typeDir}/`;
+    return p;
+}
+
+async function selectComponent(prefix) {
+    for (const fn of activeCleanups) fn();
+    activeCleanups = [];
+
+    setSelectedTreeItem(prefix);
+
+    const panel = document.getElementById('detailPanel');
+    const name = componentNameFromPrefix(prefix);
+    const path = s3PathForPrefix(prefix);
+
+    panel.innerHTML = `
+        <div class="detail-heading">${escapeHtml(name)}</div>
+        <div class="detail-path"><a href="${escapeHtml(s3ConsoleUrl(prefix))}" target="_blank" rel="noopener">${escapeHtml(path)}</a></div>
+    `;
+
+    const contentDiv = document.createElement('div');
+    contentDiv.className = 'component-content';
+    panel.appendChild(contentDiv);
+
+    let themeTypes;
+    try {
+        themeTypes = await fetchThemeTypes(prefix);
+    } catch (err) {
+        console.error('fetchThemeTypes error:', err);
+        themeTypes = { themes: [], types_by_theme: {} };
+    }
+
+    const { themes, theme_dirs, types_by_theme } = themeTypes;
+
+    // No Hive partitions: render directly with original prefix
+    if (themes.length === 0) {
+        await renderComponentContent(contentDiv, prefix, name);
+        return;
+    }
+
+    // Render selector (even for single combo, so user sees what's selected)
+    const selectorDiv = document.createElement('div');
+    selectorDiv.className = 'theme-type-selector';
+    panel.insertBefore(selectorDiv, contentDiv);
+
+    // Theme dropdown: display labels as text, raw dir names as values
+    const themeSelect = document.createElement('select');
+    for (let i = 0; i < themes.length; i++) {
+        const opt = document.createElement('option');
+        opt.value = theme_dirs[i];
+        opt.textContent = themes[i];
+        themeSelect.appendChild(opt);
+    }
+
+    const typeSelect = document.createElement('select');
+
+    function populateTypes(themeLabel) {
+        typeSelect.innerHTML = '';
+        const typeDirs = types_by_theme[themeLabel] || [];
+        if (typeDirs.length === 0) {
+            typeSelect.style.display = 'none';
+            typeLabel.style.display = 'none';
+        } else {
+            typeSelect.style.display = '';
+            typeLabel.style.display = '';
+            for (const dir of typeDirs) {
+                const opt = document.createElement('option');
+                opt.value = dir;
+                // Strip "type=" prefix for display if present
+                opt.textContent = dir.includes('=') ? dir.split('=')[1] : dir;
+                typeSelect.appendChild(opt);
+            }
+        }
+    }
+
+    function selectedThemeLabel() {
+        const idx = themeSelect.selectedIndex;
+        return idx >= 0 ? themes[idx] : themes[0];
+    }
+
+    async function renderSelected() {
+        for (const fn of activeCleanups) fn();
+        activeCleanups = [];
+        contentDiv.innerHTML = '';
+        const themeDir = themeSelect.value;
+        const typeDir = typeSelect.value || null;
+        const narrowed = buildNarrowedPrefix(prefix, themeDir, typeDir);
+        await renderComponentContent(contentDiv, narrowed, name);
+    }
+
+    const themeLabel = document.createElement('label');
+    themeLabel.textContent = 'Theme';
+    const typeLabel = document.createElement('label');
+    typeLabel.textContent = 'Type';
+
+    selectorDiv.appendChild(themeLabel);
+    selectorDiv.appendChild(themeSelect);
+    selectorDiv.appendChild(typeLabel);
+    selectorDiv.appendChild(typeSelect);
+
+    populateTypes(themes[0]);
+
+    themeSelect.addEventListener('change', () => {
+        populateTypes(selectedThemeLabel());
+        renderSelected();
+    });
+    typeSelect.addEventListener('change', () => renderSelected());
+
+    await renderSelected();
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/core.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/core.js
@@ -1,0 +1,207 @@
+// Shared state, API helpers, and utilities.
+
+const API_BASE = '/api/bundle-inspector';
+
+const state = {
+    config: null,
+    tree: {},
+    selectedPrefix: null,
+    user: null,
+    stageInfo: {},
+};
+
+// -- Utilities ------------------------------------------------
+
+function domIdForPrefix(prefix) {
+    return 'ch-' + btoa(prefix).replace(/=/g, '_');
+}
+
+function escapeHtml(str) {
+    const d = document.createElement('div');
+    d.textContent = str;
+    return d.innerHTML;
+}
+
+function formatSize(bytes) {
+    if (bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const val = bytes / Math.pow(1024, i);
+    return `${val < 10 ? val.toFixed(1) : Math.round(val)} ${units[i]}`;
+}
+
+function s3PathForPrefix(prefix) {
+    const c = state.config;
+    const ns = state.user || c.namespace;
+    let path = `s3://${c.bucket}/`;
+    if (c.environment === 'dev' && ns) path += `${ns}/`;
+    return path + prefix;
+}
+
+function s3ConsoleUrl(prefix) {
+    const c = state.config;
+    const ns = state.user || c.namespace;
+    let key = '';
+    if (c.environment === 'dev' && ns) key += `${ns}/`;
+    key += prefix;
+    return `https://${c.aws_region || 'us-west-2'}.console.aws.amazon.com/s3/buckets/${c.bucket}?prefix=${encodeURIComponent(key)}`;
+}
+
+function setSelectedTreeItem(prefix) {
+    document.querySelectorAll('.tree-item.selected').forEach(el => el.classList.remove('selected'));
+    const row = document.querySelector(`.tree-item[data-prefix="${CSS.escape(prefix)}"]`);
+    if (row) row.classList.add('selected');
+    state.selectedPrefix = prefix;
+    pushPrefixToUrl(prefix);
+}
+
+function pushPrefixToUrl(prefix) {
+    const base = '/bundle-inspector/';
+    const userPart = state.user ? state.user + '/' : '';
+    const url = base + userPart + (prefix || '');
+    if (window.location.pathname !== url) {
+        history.replaceState(null, '', url);
+    }
+}
+
+function prefixFromUrl() {
+    const path = window.location.pathname;
+    const base = '/bundle-inspector/';
+    if (!path.startsWith(base)) return null;
+    return path.slice(base.length) || null;
+}
+
+// -- API helpers ----------------------------------------------
+
+function userParam(url) {
+    if (!state.user) return '';
+    const sep = url.includes('?') ? '&' : '?';
+    return `${sep}user=${encodeURIComponent(state.user)}`;
+}
+
+async function fetchConfig() {
+    const url = `${API_BASE}/config?_=1`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`config: ${res.status}`);
+    state.config = await res.json();
+    renderSidebarInfo();
+}
+
+async function fetchChildren(prefix) {
+    const url = `${API_BASE}/list?prefix=${encodeURIComponent(prefix)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`list: ${res.status}`);
+    return await res.json();
+}
+
+
+async function fetchUsers() {
+    const res = await fetch(`${API_BASE}/users`);
+    if (!res.ok) throw new Error(`users: ${res.status}`);
+    return await res.json();
+}
+
+async function fetchThemeTypes(prefix) {
+    const url = `${API_BASE}/theme-types?prefix=${encodeURIComponent(prefix)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`theme-types: ${res.status}`);
+    return await res.json();
+}
+
+async function fetchCount(prefix) {
+    const url = `${API_BASE}/count?prefix=${encodeURIComponent(prefix)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`count: ${res.status}`);
+    return await res.json();
+}
+
+async function fetchParquetStats(prefix) {
+    const url = `${API_BASE}/parquet-stats?prefix=${encodeURIComponent(prefix)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`parquet-stats: ${res.status}`);
+    return await res.json();
+}
+
+async function fetchTree(prefix) {
+    const url = `${API_BASE}/tree?prefix=${encodeURIComponent(prefix)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    if (!res.ok) throw new Error(`tree: ${res.status}`);
+    return await res.json();
+}
+
+async function fetchAthenaStart(sql) {
+    const params = new URLSearchParams({ sql });
+    const url = `${API_BASE}/athena-query?${params}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    return await res.json();
+}
+
+async function fetchAthenaStatus(queryId) {
+    const url = `${API_BASE}/athena-status?query_id=${encodeURIComponent(queryId)}`;
+    const res = await fetch(`${url}${userParam(url)}`);
+    return await res.json();
+}
+
+async function fetchAthenaQuery(sql, onStatus) {
+    const start = await fetchAthenaStart(sql);
+    if (start.error) return start;
+    const queryId = start.query_id;
+
+    const POLL_INTERVAL = 1000;
+    const TIMEOUT = 5 * 60 * 1000;
+    const deadline = Date.now() + TIMEOUT;
+
+    while (Date.now() < deadline) {
+        const status = await fetchAthenaStatus(queryId);
+        if (onStatus) onStatus(status.state);
+        if (status.state === 'SUCCEEDED') return status;
+        if (status.state === 'FAILED' || status.state === 'CANCELLED') return status;
+        await new Promise(r => setTimeout(r, POLL_INTERVAL));
+    }
+    return { error: 'Query timed out after 5 minutes.' };
+}
+
+// -- Sidebar info ---------------------------------------------
+
+function renderSidebarInfo() {
+    const el = document.getElementById('sidebarInfo');
+    if (!state.config) { el.textContent = ''; return; }
+    const c = state.config;
+    let html = `<div>Bucket: ${escapeHtml(c.bucket)}</div>`;
+    if (c.environment) html += `<div>Environment: ${escapeHtml(c.environment)}</div>`;
+    if (c.environment === 'dev' && c.namespace) html += `<div>User: ${escapeHtml(c.namespace)}</div>`;
+    el.innerHTML = html;
+}
+
+// -- User selector --------------------------------------------
+
+async function loadUserSelector() {
+    if (!state.config || state.config.environment !== 'dev') return;
+    try {
+        const data = await fetchUsers();
+        if (!data.users || data.users.length === 0) return;
+
+        const selector = document.getElementById('userSelector');
+        const select = document.getElementById('userSelect');
+        selector.style.display = 'block';
+
+        select.innerHTML = '';
+        const activeUser = state.user || state.config.namespace;
+        for (const u of data.users) {
+            const opt = document.createElement('option');
+            opt.value = u;
+            opt.textContent = u;
+            if (u === activeUser) opt.selected = true;
+            select.appendChild(opt);
+        }
+    } catch (err) {
+        console.error('loadUserSelector error:', err);
+    }
+}
+
+async function onUserChange() {
+    const select = document.getElementById('userSelect');
+    state.user = select.value;
+    pushPrefixToUrl(null);
+    await refresh();
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/csv-utils.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/csv-utils.js
@@ -1,0 +1,78 @@
+// Shared CSV parsing utilities.
+// RFC 4180-aware row splitter and full-text parser.
+
+// Split a single CSV row (already extracted by splitCsvLines) into fields,
+// handling quoted fields with embedded commas and escaped quotes (double-quote pairs).
+function splitCsvRow(line) {
+    const fields = [];
+    let i = 0;
+    while (i <= line.length) {
+        if (i === line.length) { fields.push(''); break; }
+        if (line[i] === '"') {
+            let val = '';
+            i++; // skip opening quote
+            while (i < line.length) {
+                if (line[i] === '"') {
+                    if (i + 1 < line.length && line[i + 1] === '"') {
+                        val += '"';
+                        i += 2;
+                    } else {
+                        i++; // skip closing quote
+                        break;
+                    }
+                } else {
+                    val += line[i++];
+                }
+            }
+            fields.push(val);
+            if (i < line.length && line[i] === ',') i++; // skip delimiter
+        } else {
+            const next = line.indexOf(',', i);
+            if (next === -1) {
+                fields.push(line.slice(i));
+                break;
+            }
+            fields.push(line.slice(i, next));
+            i = next + 1;
+        }
+    }
+    return fields;
+}
+
+// Split CSV text into rows, respecting quoted fields that contain newlines.
+// Returns an array of parsed row arrays (each row is an array of field strings).
+function splitCsvLines(text) {
+    const rows = [];
+    let i = 0;
+    const len = text.length;
+    while (i < len) {
+        // Skip leading CRLF/LF left over from previous row
+        if (text[i] === '\r' || text[i] === '\n') { i++; continue; }
+        let lineStart = i;
+        let inQuote = false;
+        while (i < len) {
+            const ch = text[i];
+            if (ch === '"') {
+                if (inQuote && i + 1 < len && text[i + 1] === '"') {
+                    i += 2; continue;
+                }
+                inQuote = !inQuote;
+            } else if ((ch === '\n' || ch === '\r') && !inQuote) {
+                break;
+            }
+            i++;
+        }
+        const line = text.slice(lineStart, i);
+        if (line.length > 0) rows.push(splitCsvRow(line));
+        if (i < len && text[i] === '\r') i++;
+        if (i < len && text[i] === '\n') i++;
+    }
+    return rows;
+}
+
+// Parse a complete CSV text block into {columns, rows}.
+function parseCsv(text) {
+    const allRows = splitCsvLines(text);
+    if (allRows.length === 0) return { columns: [], rows: [] };
+    return { columns: allRows[0], rows: allRows.slice(1) };
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/detail.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/detail.js
@@ -1,0 +1,55 @@
+// Run-level detail panel and recent bundles.
+// Depends on: core.js
+
+function renderDetail(prefix, data) {
+    const panel = document.getElementById('detailPanel');
+    if (!data) {
+        panel.innerHTML = '<div class="detail-empty">Select a node to inspect.</div>';
+        return;
+    }
+
+    const successChip = data.has_success
+        ? '<span class="status-chip success">\u2714 success</span>'
+        : '<span class="status-chip absent">\u2718 no success</span>';
+
+    const metadataChip = data.has_metadata
+        ? '<span class="status-chip success">\u2714 metadata.json</span>'
+        : '<span class="status-chip neutral">no metadata</span>';
+
+    const dirs = (data.children || []).filter(c => c.type === 'directory');
+    const files = (data.children || []).filter(c => c.type === 'file');
+    const mdFiles = files.filter(f => f.name.endsWith('.md'));
+    const otherFiles = files.filter(f => !f.name.endsWith('.md'));
+
+    let componentsHtml = '';
+    if (dirs.length > 0) {
+        componentsHtml += `<div class="detail-section-title">Components (${dirs.length})</div>`;
+        componentsHtml += '<ul class="component-list">';
+        for (const d of dirs) {
+            componentsHtml += `<li><span class="component-icon">&#128193;</span> ${escapeHtml(d.name.replace(/\/$/, ''))}</li>`;
+        }
+        componentsHtml += '</ul>';
+    }
+    if (otherFiles.length > 0) {
+        componentsHtml += `<div class="detail-section-title">Files (${otherFiles.length})</div>`;
+        componentsHtml += '<ul class="component-list">';
+        for (const f of otherFiles) {
+            const size = f.size != null ? ` (${formatSize(f.size)})` : '';
+            componentsHtml += `<li><span class="component-icon">&#128196;</span> ${escapeHtml(f.name)}${size}</li>`;
+        }
+        componentsHtml += '</ul>';
+    }
+
+    panel.innerHTML = `
+        <div class="detail-heading">Run</div>
+        <div class="detail-path"><a href="${escapeHtml(s3ConsoleUrl(prefix))}" target="_blank" rel="noopener">${escapeHtml(s3PathForPrefix(prefix))}</a></div>
+        <div class="detail-status">${successChip} ${metadataChip}</div>
+        ${(componentsHtml || mdFiles.length > 0) ? componentsHtml : '<div style="color:#6c757d;font-style:italic;">No children found.</div>'}
+    `;
+
+    if (mdFiles.length > 0) {
+        const mdContainer = document.createElement('div');
+        panel.appendChild(mdContainer);
+        renderMarkdownFiles(mdContainer, prefix, mdFiles);
+    }
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/map-utils.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/map-utils.js
@@ -1,0 +1,46 @@
+// Shared map utilities for MapLibre GL components.
+
+const CARTO_STYLE = {
+    version: 8,
+    sources: {
+        'carto': {
+            type: 'raster',
+            tiles: ['https://basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'],
+            tileSize: 256,
+            attribution: '&copy; OpenStreetMap &copy; CARTO',
+        },
+    },
+    layers: [{
+        id: 'carto-tiles',
+        type: 'raster',
+        source: 'carto',
+    }],
+};
+
+// Extend a maplibregl.LngLatBounds with all coordinates in a geometry.
+function collectBounds(geometry, bounds) {
+    if (!geometry) return;
+    const type = geometry.type;
+    if (type === 'Point') {
+        bounds.extend(geometry.coordinates);
+    } else if (type === 'MultiPoint' || type === 'LineString') {
+        for (const coord of geometry.coordinates) bounds.extend(coord);
+    } else if (type === 'MultiLineString' || type === 'Polygon') {
+        for (const ring of geometry.coordinates)
+            for (const coord of ring) bounds.extend(coord);
+    } else if (type === 'MultiPolygon') {
+        for (const polygon of geometry.coordinates)
+            for (const ring of polygon)
+                for (const coord of ring) bounds.extend(coord);
+    } else if (type === 'GeometryCollection') {
+        for (const geom of geometry.geometries) collectBounds(geom, bounds);
+    }
+}
+
+// Fit a map to the bounds of a GeoJSON FeatureCollection.
+function fitMapToFeatures(map, features) {
+    if (features.length === 0) return;
+    const bounds = new maplibregl.LngLatBounds();
+    for (const f of features) collectBounds(f.geometry, bounds);
+    map.fitBounds(bounds, { padding: 40 });
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/style.css
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/style.css
@@ -1,0 +1,625 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",
+        "Helvetica Neue", sans-serif;
+    font-size: 13px;
+    color: #333;
+}
+
+.plugin-header {
+    background: #1e1e1e;
+    border-bottom: 2px solid #3578e5;
+    padding: 12px 20px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+}
+
+.plugin-header a {
+    color: #fff;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 13px;
+}
+
+.plugin-header a:hover {
+    color: #3578e5;
+}
+
+.container {
+    display: flex;
+    height: calc(100vh - 48px);
+    overflow: hidden;
+}
+
+/* -- Sidebar -- */
+.sidebar {
+    width: 340px;
+    min-width: 340px;
+    border-right: 1px solid #ddd;
+    overflow-y: auto;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-header {
+    padding: 14px 14px 0;
+}
+
+.sidebar-header h1 {
+    margin: 0 0 10px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+    border-bottom: 2px solid #ddd;
+    padding-bottom: 8px;
+}
+
+.sidebar-controls {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+
+.btn {
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s ease;
+}
+
+.btn-secondary {
+    background: #fff;
+    color: #333;
+}
+
+.btn-secondary:hover {
+    background: #f0f0f0;
+}
+
+.btn-primary {
+    background: #3578e5;
+    color: #fff;
+    border-color: #3578e5;
+}
+
+.btn-primary:hover {
+    background: #2a63c0;
+    border-color: #2a63c0;
+}
+
+.user-selector {
+    display: none;
+    margin-bottom: 10px;
+}
+
+.user-selector label {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.user-selector select {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 13px;
+    color: #333;
+    background: #fff;
+}
+
+.user-selector select:focus {
+    outline: none;
+    border-color: #3578e5;
+}
+
+.sidebar-info {
+    font-size: 12px;
+    color: #666;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #eee;
+    line-height: 1.4;
+}
+
+.tree-container {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 0;
+}
+
+/* -- Tree items -- */
+.tree-item {
+    display: flex;
+    align-items: center;
+    padding: 4px 12px;
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+    font-size: 13px;
+    line-height: 1.6;
+    transition: background 0.1s ease;
+}
+
+.tree-item:hover {
+    background: #f5f5f5;
+}
+
+.tree-item.selected {
+    background: #e3f2fd;
+}
+
+.tree-toggle {
+    display: inline-block;
+    width: 16px;
+    text-align: center;
+    color: #666;
+    flex-shrink: 0;
+    font-size: 11px;
+}
+
+.tree-label {
+    margin-left: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tree-label.dir {
+    font-weight: 600;
+    color: #333;
+}
+
+.tree-label.file {
+    color: #666;
+}
+
+.tree-label.component {
+    font-weight: 500;
+    color: #3578e5;
+}
+
+.tree-status {
+    margin-left: 6px;
+    flex-shrink: 0;
+    font-size: 12px;
+}
+
+.tree-children {
+    display: none;
+}
+
+.tree-children.expanded {
+    display: block;
+}
+
+.tree-loading {
+    padding: 4px 12px;
+    font-size: 12px;
+    color: #666;
+    font-style: italic;
+}
+
+
+/* -- Detail panel -- */
+.detail-panel {
+    flex: 1;
+    padding: 24px;
+    overflow-y: auto;
+    background: #fff;
+}
+
+.detail-empty {
+    color: #666;
+    font-style: italic;
+    margin-top: 40px;
+    text-align: center;
+}
+
+.detail-heading {
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+    margin: 0 0 14px;
+}
+
+.detail-path {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 12px;
+    color: #333;
+    background: #f5f5f5;
+    padding: 10px 12px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    word-break: break-all;
+    margin-bottom: 14px;
+}
+
+.detail-status {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.status-chip.success {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.status-chip.absent {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.status-chip.neutral {
+    background: #f0f0f0;
+    color: #555;
+}
+
+.detail-section-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin: 16px 0 8px;
+    color: #333;
+}
+
+.component-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.component-list li {
+    padding: 6px 10px;
+    font-size: 13px;
+    border-bottom: 1px solid #eee;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.component-list li:last-child {
+    border-bottom: none;
+}
+
+.component-icon {
+    color: #3578e5;
+    flex-shrink: 0;
+}
+
+.component-map {
+    width: 100%;
+    height: 500px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.bbox-filter-hint {
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+    color: #6c757d;
+    margin-top: 4px;
+    padding: 2px 4px;
+    cursor: pointer;
+    user-select: all;
+    border-radius: 3px;
+    transition: background-color 0.15s;
+}
+
+.bbox-filter-hint:hover {
+    background-color: #f0f0f0;
+}
+
+.bbox-filter-hint.copied {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.spinner-inline {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid #3578e5;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.theme-type-selector {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 14px;
+}
+
+.theme-type-selector label {
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.theme-type-selector select {
+    padding: 6px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 13px;
+    color: #333;
+    background: #fff;
+}
+
+.theme-type-selector select:focus {
+    outline: none;
+    border-color: #3578e5;
+}
+
+/* Parquet stats */
+
+.parquet-stats-table {
+    border-collapse: collapse;
+    font-size: 13px;
+    margin-top: 8px;
+}
+
+.parquet-stats-table td {
+    padding: 3px 16px 3px 0;
+}
+
+.parquet-stats-table td:first-child {
+    color: #6c757d;
+    white-space: nowrap;
+}
+
+.parquet-schema-table {
+    border-collapse: collapse;
+    font-size: 12px;
+    width: 100%;
+    margin-top: 6px;
+}
+
+.parquet-schema-table th {
+    text-align: left;
+    font-weight: 600;
+    padding: 4px 12px 4px 0;
+    border-bottom: 1px solid #e0e0e0;
+    color: #6c757d;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.parquet-schema-table td {
+    padding: 3px 12px 3px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.parquet-schema-table td:last-child {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 11px;
+    color: #6c757d;
+}
+
+/* Component stacking */
+
+.component-section + .component-section {
+    margin-top: 8px;
+}
+
+/* Athena preview */
+
+.athena-editor {
+    margin-top: 8px;
+}
+
+.athena-sql {
+    width: 100%;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 12px;
+    padding: 8px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    resize: vertical;
+    color: #333;
+    background: #fafafa;
+    line-height: 1.5;
+}
+
+.athena-sql:focus {
+    outline: none;
+    border-color: #3578e5;
+}
+
+.athena-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 8px;
+}
+
+.athena-status {
+    font-size: 12px;
+    color: #6c757d;
+}
+
+.athena-error {
+    margin-top: 10px;
+    padding: 10px 12px;
+    background: #fee2e2;
+    color: #991b1b;
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.athena-table-wrap {
+    margin-top: 10px;
+    overflow-x: auto;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+}
+
+.athena-table {
+    border-collapse: collapse;
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.athena-table th {
+    text-align: left;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-bottom: 1px solid #e0e0e0;
+    background: #f5f5f5;
+    color: #333;
+    font-size: 11px;
+    position: sticky;
+    top: 0;
+}
+
+.athena-table td {
+    padding: 4px 12px;
+    border-bottom: 1px solid #f0f0f0;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 11px;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.athena-table tbody tr:hover {
+    background: #f5f5f5;
+}
+
+.athena-status-bar {
+    margin-top: 8px;
+    font-size: 11px;
+    color: #6c757d;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.athena-load-more {
+    font-size: 11px;
+    padding: 2px 10px;
+}
+
+.athena-download {
+    color: #3578e5;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.athena-download:hover {
+    text-decoration: underline;
+}
+
+pre.folder-tree {
+    font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    background: #fafafa;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 12px 16px;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+    color: #333;
+    margin: 0;
+}
+
+/* Markdown viewer */
+.markdown-section {
+    margin-top: 16px;
+}
+
+.markdown-body {
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 16px 20px;
+    line-height: 1.6;
+    overflow-x: auto;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3 {
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 0.3em;
+}
+
+.markdown-body h1:first-child,
+.markdown-body h2:first-child,
+.markdown-body h3:first-child {
+    margin-top: 0;
+}
+
+.markdown-body pre {
+    background: #f6f8fa;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+    padding: 12px;
+    overflow-x: auto;
+}
+
+.markdown-body code {
+    background: #f0f0f0;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+.markdown-body pre code {
+    background: none;
+    padding: 0;
+}
+
+.markdown-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 8px 0;
+}
+
+.markdown-body th,
+.markdown-body td {
+    border: 1px solid #ddd;
+    padding: 6px 10px;
+    text-align: left;
+}
+
+.markdown-body th {
+    background: #f6f8fa;
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/tree.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/tree.js
@@ -1,0 +1,238 @@
+// Tree rendering and navigation.
+// Depends on: core.js, components/registry.js
+
+function depthForPrefix(prefix) {
+    if (!prefix) return 0;
+    return prefix.replace(/\/$/, '').split('/').length;
+}
+
+function stageForPrefix(prefix) {
+    if (!prefix) return null;
+    return prefix.split('/')[0];
+}
+
+function runDepthForStage(stage) {
+    const info = state.stageInfo[stage];
+    if (info) return info.run_depth;
+    if (stage === 'release_candidate') return 3;
+    return 4;
+}
+
+function displayName(rawName) {
+    const stripped = rawName.replace(/\/$/, '');
+    const eqIdx = stripped.indexOf('=');
+    if (eqIdx !== -1) return stripped.substring(eqIdx + 1);
+    return stripped;
+}
+
+function hierarchyLabel(stage, nodeDepth) {
+    const info = state.stageInfo[stage];
+    if (!info || !info.hierarchy) return '';
+    const idx = nodeDepth - 2;
+    if (idx < 0 || idx >= info.hierarchy.length) return '';
+    const label = info.hierarchy[idx];
+    return label.startsWith('!') ? label.slice(1) : label;
+}
+
+function labelForNode(stage, nodeDepth) {
+    if (nodeDepth === 1) return 'stage';
+    return hierarchyLabel(stage, nodeDepth);
+}
+
+function isComponentNode(prefix) {
+    const stage = stageForPrefix(prefix);
+    if (!stage) return false;
+    return depthForPrefix(prefix) === runDepthForStage(stage) + 1;
+}
+
+function isRunLevelNode(prefix) {
+    const stage = stageForPrefix(prefix);
+    if (!stage) return false;
+    return depthForPrefix(prefix) === runDepthForStage(stage);
+}
+
+// -- Rendering ------------------------------------------------
+
+function renderNode(item, parentPrefix, parentDepth, parentEl) {
+    const fullPrefix = parentPrefix + item.name;
+    const isDir = item.type === 'directory';
+    const nodeDepth = depthForPrefix(fullPrefix);
+    const stage = stageForPrefix(fullPrefix);
+    const component = isDir && isComponentNode(fullPrefix);
+
+    const row = document.createElement('div');
+    row.className = 'tree-item';
+    row.style.paddingLeft = `${12 + parentDepth * 16}px`;
+    row.dataset.prefix = fullPrefix;
+
+    const toggle = document.createElement('span');
+    toggle.className = 'tree-toggle';
+
+    const label = document.createElement('span');
+
+    if (component) {
+        toggle.textContent = ' ';
+        label.className = 'tree-label component';
+        label.textContent = displayName(item.name);
+        row.addEventListener('click', () => selectComponent(fullPrefix));
+    } else if (isDir) {
+        const cached = state.tree[fullPrefix];
+        toggle.textContent = cached && cached.expanded ? 'v' : '>';
+        label.className = 'tree-label dir';
+
+        const hint = labelForNode(stage, nodeDepth);
+        const display = displayName(item.name);
+        label.textContent = hint ? `${hint}: ${display}` : display;
+
+        row.addEventListener('click', () => toggleNode(fullPrefix));
+    } else {
+        toggle.textContent = ' ';
+        label.className = 'tree-label file';
+        label.textContent = item.name;
+    }
+
+    row.appendChild(toggle);
+    row.appendChild(label);
+
+    if (isDir && isRunLevelNode(fullPrefix)) {
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'tree-status';
+        row.appendChild(statusSpan);
+    }
+
+    parentEl.appendChild(row);
+
+    if (isDir && !component) {
+        const childContainer = document.createElement('div');
+        childContainer.className = 'tree-children';
+        childContainer.id = domIdForPrefix(fullPrefix);
+        parentEl.appendChild(childContainer);
+
+        const cached = state.tree[fullPrefix];
+        if (cached && cached.expanded && cached.children) {
+            childContainer.classList.add('expanded');
+            renderChildren(cached.children, fullPrefix, depthForPrefix(fullPrefix), childContainer);
+        }
+    }
+}
+
+function renderChildren(items, parentPrefix, depth, containerEl) {
+    containerEl.innerHTML = '';
+    for (const item of items) {
+        renderNode(item, parentPrefix, depth, containerEl);
+    }
+}
+
+// -- Toggle / expand ------------------------------------------
+
+async function toggleNode(prefix) {
+    const cached = state.tree[prefix];
+    const container = document.getElementById(domIdForPrefix(prefix));
+    if (!container) return;
+
+    if (cached && cached.expanded) {
+        cached.expanded = false;
+        container.classList.remove('expanded');
+        updateToggleIcon(prefix, false);
+        return;
+    }
+
+    if (cached && cached.children) {
+        cached.expanded = true;
+        container.classList.add('expanded');
+        updateToggleIcon(prefix, true);
+        selectIfRunLevel(prefix, cached.data);
+        return;
+    }
+
+    const loadingEl = document.createElement('div');
+    loadingEl.className = 'tree-loading';
+    loadingEl.innerHTML = '<span class="spinner-inline"></span> Loading...';
+    container.innerHTML = '';
+    container.appendChild(loadingEl);
+    container.classList.add('expanded');
+    updateToggleIcon(prefix, true);
+
+    try {
+        const data = await fetchChildren(prefix);
+
+        if (data.stage) {
+            state.stageInfo[data.stage] = {
+                run_depth: data.run_depth,
+                hierarchy: data.hierarchy,
+            };
+        }
+
+        state.tree[prefix] = {
+            expanded: true,
+            children: data.children,
+            data: data,
+        };
+
+        renderChildren(data.children, prefix, depthForPrefix(prefix), container);
+        updateRunStatusIcon(prefix, data);
+        selectIfRunLevel(prefix, data);
+    } catch (err) {
+        container.innerHTML = '<div class="tree-loading" style="color:#dc3545;">Error loading</div>';
+        console.error('toggleNode error:', err);
+    }
+}
+
+function updateToggleIcon(prefix, expanded) {
+    const row = document.querySelector(`.tree-item[data-prefix="${CSS.escape(prefix)}"]`);
+    if (!row) return;
+    const toggle = row.querySelector('.tree-toggle');
+    if (toggle) toggle.textContent = expanded ? 'v' : '>';
+}
+
+function updateRunStatusIcon(prefix, data) {
+    if (!isRunLevelNode(prefix)) return;
+    const row = document.querySelector(`.tree-item[data-prefix="${CSS.escape(prefix)}"]`);
+    if (!row) return;
+    const statusSpan = row.querySelector('.tree-status');
+    if (!statusSpan) return;
+    statusSpan.textContent = data.has_success ? '\u2714' : '\u2718';
+    statusSpan.style.color = data.has_success ? '#96C93D' : '#dc3545';
+}
+
+function selectIfRunLevel(prefix, data) {
+    if (!isRunLevelNode(prefix)) return;
+    selectNode(prefix, data);
+}
+
+function selectNode(prefix, data) {
+    for (const fn of activeCleanups) fn();
+    activeCleanups = [];
+    setSelectedTreeItem(prefix);
+    renderDetail(prefix, data);
+}
+
+// -- Expand to path -------------------------------------------
+
+async function expandToPath(prefix) {
+    const parts = prefix.replace(/\/$/, '').split('/');
+    const progressivePrefixes = [];
+    for (let i = 0; i < parts.length; i++) {
+        progressivePrefixes.push(parts.slice(0, i + 1).join('/') + '/');
+    }
+
+    if (document.getElementById('treeRoot').children.length === 0) {
+        await loadRoot();
+    }
+
+    for (const p of progressivePrefixes) {
+        const cached = state.tree[p];
+        if (!cached || !cached.expanded) {
+            await toggleNode(p);
+        }
+    }
+
+    const finalPrefix = progressivePrefixes[progressivePrefixes.length - 1];
+    const finalCached = state.tree[finalPrefix];
+    if (finalCached) {
+        selectNode(finalPrefix, finalCached.data);
+    }
+
+    const row = document.querySelector(`.tree-item[data-prefix="${CSS.escape(finalPrefix)}"]`);
+    if (row) row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+}

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/wkb.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/wkb.js
@@ -1,0 +1,153 @@
+// Minimal WKB hex to GeoJSON decoder.
+// Handles Point, LineString, Polygon, and their Multi* variants,
+// plus GeometryCollection. Both byte orders (big/little endian).
+
+function parseWkbHex(raw) {
+    try {
+        const hex = raw.replace(/\s+/g, '');
+        const bytes = new Uint8Array(hex.length / 2);
+        for (let i = 0; i < bytes.length; i++) {
+            bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+        }
+        const view = new DataView(bytes.buffer);
+        const result = readGeometry(view, 0);
+        return result.geometry;
+    } catch {
+        return null;
+    }
+}
+
+function readGeometry(view, offset) {
+    const byteOrder = view.getUint8(offset);
+    const le = byteOrder === 1;
+    offset += 1;
+
+    let wkbType = view.getUint32(offset, le);
+    offset += 4;
+
+    // Detect Z/M dimensions from EWKB flags or ISO WKB type ranges
+    const hasSRID = (wkbType & 0x20000000) !== 0;
+    const hasZ = (wkbType & 0x80000000) !== 0 || (Math.floor(wkbType / 1000) % 10 === 1) || (Math.floor(wkbType / 1000) % 10 === 3);
+    const hasM = (wkbType & 0x40000000) !== 0 || (Math.floor(wkbType / 1000) % 10 === 2) || (Math.floor(wkbType / 1000) % 10 === 3);
+    // Coordinate stride: 2 (XY) + Z? + M?
+    const coordSize = (2 + (hasZ ? 1 : 0) + (hasM ? 1 : 0)) * 8;
+    // Normalize to base type (1-7)
+    const baseType = (wkbType & 0xFF) || (wkbType % 1000);
+    if (hasSRID) offset += 4;
+
+    switch (baseType) {
+        case 1: return readPoint(view, offset, le, coordSize);
+        case 2: return readLineString(view, offset, le, coordSize);
+        case 3: return readPolygon(view, offset, le, coordSize);
+        case 4: return readMulti(view, offset, le, 'MultiPoint');
+        case 5: return readMulti(view, offset, le, 'MultiLineString');
+        case 6: return readMulti(view, offset, le, 'MultiPolygon');
+        case 7: return readGeometryCollection(view, offset, le);
+        default: throw new Error('Unknown WKB type: ' + wkbType);
+    }
+}
+
+function readCoord(view, offset, le, coordSize) {
+    const x = view.getFloat64(offset, le);
+    const y = view.getFloat64(offset + 8, le);
+    return { coord: [x, y], offset: offset + (coordSize || 16) };
+}
+
+function readPoint(view, offset, le, coordSize) {
+    const { coord, offset: next } = readCoord(view, offset, le, coordSize);
+    return { geometry: { type: 'Point', coordinates: coord }, offset: next };
+}
+
+function readCoordArray(view, offset, le, coordSize) {
+    const count = view.getUint32(offset, le);
+    offset += 4;
+    const coords = [];
+    for (let i = 0; i < count; i++) {
+        const { coord, offset: next } = readCoord(view, offset, le, coordSize);
+        coords.push(coord);
+        offset = next;
+    }
+    return { coords, offset };
+}
+
+function readLineString(view, offset, le, coordSize) {
+    const { coords, offset: next } = readCoordArray(view, offset, le, coordSize);
+    return { geometry: { type: 'LineString', coordinates: coords }, offset: next };
+}
+
+function readPolygon(view, offset, le, coordSize) {
+    const ringCount = view.getUint32(offset, le);
+    offset += 4;
+    const rings = [];
+    for (let i = 0; i < ringCount; i++) {
+        const { coords, offset: next } = readCoordArray(view, offset, le, coordSize);
+        rings.push(coords);
+        offset = next;
+    }
+    return { geometry: { type: 'Polygon', coordinates: rings }, offset };
+}
+
+function readMulti(view, offset, le, type) {
+    const count = view.getUint32(offset, le);
+    offset += 4;
+    const parts = [];
+    for (let i = 0; i < count; i++) {
+        const result = readGeometry(view, offset);
+        parts.push(result.geometry.coordinates);
+        offset = result.offset;
+    }
+    return { geometry: { type, coordinates: parts }, offset };
+}
+
+function readGeometryCollection(view, offset, le) {
+    const count = view.getUint32(offset, le);
+    offset += 4;
+    const geometries = [];
+    for (let i = 0; i < count; i++) {
+        const result = readGeometry(view, offset);
+        geometries.push(result.geometry);
+        offset = result.offset;
+    }
+    return { geometry: { type: 'GeometryCollection', geometries }, offset };
+}
+
+const WKB_HEX_RE = /^[0-9a-fA-F\s]+$/;
+const VALID_WKB_TYPES = new Set([1, 2, 3, 4, 5, 6, 7]);
+
+// Detect which column (if any) contains WKB hex geometry.
+// Returns the column index, or -1 if none found.
+function detectGeometryColumn(columns, firstRow) {
+    for (let i = 0; i < firstRow.length; i++) {
+        const raw = firstRow[i];
+        if (!raw || raw.length < 10) continue;
+        if (!WKB_HEX_RE.test(raw)) continue;
+
+        const val = raw.replace(/\s+/g, '');
+        if (val.length % 2 !== 0) continue;
+
+        // Check the WKB type byte
+        const endian = parseInt(val.slice(0, 2), 16);
+        let rawType;
+        if (endian === 1) { // little-endian: type is bytes 1-4, LSB first
+            rawType = parseInt(val.slice(2, 4), 16);
+        } else { // big-endian: type is bytes 1-4, MSB first
+            rawType = parseInt(val.slice(8, 10), 16);
+        }
+        if (!VALID_WKB_TYPES.has(rawType & 0xFF)) continue;
+
+        // Confirm by attempting a full decode
+        if (parseWkbHex(raw)) return i;
+    }
+    return -1;
+}
+
+// Average of all vertices in a geometry -- used as a marker position, not a true centroid.
+function vertexAverage(geometry) {
+    let sx = 0, sy = 0, n = 0;
+    (function walk(coords) {
+        if (typeof coords[0] === 'number') { sx += coords[0]; sy += coords[1]; n++; }
+        else for (const c of coords) walk(c);
+    })(geometry.coordinates || []);
+    return n ? [sx / n, sy / n] : [0, 0];
+}
+

--- a/src/overture_airflow_provider/plugins/bundle_inspector/templates/bundle_inspector/index.html
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/templates/bundle_inspector/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bundle Inspector - Airflow</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maplibre-gl@4.7.1/dist/maplibre-gl.css" integrity="sha384-MinO0mNliZ3vwppuPOUnGa+iq619pfMhLVUXfC4LHwSCvF9H+6P/KO4Q7qBOYV5V" crossorigin="anonymous">
+    <link rel="stylesheet" href="/bundle-inspector/static/bundle_inspector/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.min.css" integrity="sha384-rCCjoCPCsizaAAYVoz1Q0CmCTvnctK0JkfCSjx7IIxexTBg+uCKtFYycedUjMyA2" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/maplibre-gl@4.7.1/dist/maplibre-gl.js" integrity="sha384-SYKAG6cglRMN0RVvhNeBY0r3FYKNOJtznwA0v7B5Vp9tr31xAHsZC0DqkQ/pZDmj" crossorigin="anonymous"></script>
+    <script type="importmap">{"imports":{"fflate":"https://cdn.jsdelivr.net/npm/fflate@0.8.2/+esm"}}</script>
+    <script>const STATIC_BASE = "/bundle-inspector/static/";</script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" integrity="sha384-ZM8fDxYm+GXOWeJcxDetoRImNnEAS7XwVFH5kv0pT6RXNy92Nemw/Sj7NfciXpqg" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-sql.min.js" integrity="sha384-/MKWdycCDliku23mP5sYXbZNuXrzgmQO/jsVxwPFn99dVOaXRyKsqDjarqpueGAp" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js" integrity="sha384-H+hy9ULve6xfxRkWIh/YOtvDdpXgV2fmAGQkIDTxIgZwNoaoBal14Di2YTMR6MzR" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div class="plugin-header">
+        <a href="/">&#8592; Back to Airflow Home</a>
+    </div>
+
+    <div class="container">
+        <div class="sidebar">
+            <div class="sidebar-header">
+                <h1>Bundle Inspector</h1>
+                <div class="user-selector" id="userSelector">
+                    <label for="userSelect">Namespace</label>
+                    <select id="userSelect" onchange="onUserChange()"></select>
+                </div>
+                <div class="sidebar-controls">
+                    <button class="btn btn-secondary" id="btnRefresh" onclick="refresh()">Refresh</button>
+                </div>
+                <div class="sidebar-info" id="sidebarInfo"></div>
+            </div>
+            <div class="tree-container" id="treeRoot"></div>
+        </div>
+
+        <div class="detail-panel" id="detailPanel">
+            <div class="detail-empty">Select a node to inspect.</div>
+        </div>
+    </div>
+
+    <!-- Load order: core -> shared utils -> registry -> components -> tree -> detail -> app -->
+    <script src="/bundle-inspector/static/bundle_inspector/core.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/csv-utils.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/map-utils.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/wkb.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/registry.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/bbox-map.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/pmtiles-viewer.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/parquet-stats.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/athena-preview.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/csv-viewer.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/markdown-viewer.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/components/folder-tree.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/tree.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/detail.js"></script>
+    <script src="/bundle-inspector/static/bundle_inspector/app.js"></script>
+</body>
+</html>

--- a/src/overture_airflow_provider/provider_info.py
+++ b/src/overture_airflow_provider/provider_info.py
@@ -46,6 +46,55 @@ def get_provider_info() -> dict:
                 "plugin-class": "overture_airflow_provider.plugins.bundle_inspector.BundleInspectorPlugin",
             }
         ],
+        "config": {
+            "bundle_inspector": {
+                "description": (
+                    "Settings for the bundle_inspector plugin (an S3 bundle browser UI, "
+                    "see plugins/bundle_inspector). Every option is also settable via its "
+                    "AIRFLOW__BUNDLE_INSPECTOR__<OPTION> environment variable."
+                ),
+                "options": {
+                    "s3_bucket": {
+                        "description": "S3 bucket containing the bundle data to browse.",
+                        "version_added": "0.7.0",
+                        "type": "string",
+                        "example": "my-overture-bundles",
+                        "default": None,
+                    },
+                    "environment": {
+                        "description": (
+                            "Environment name shown in the UI. In `dev`, the `user` option "
+                            "selects a namespace prefix under the bucket; any other value "
+                            "browses the bucket root with no namespace prefix."
+                        ),
+                        "version_added": "0.7.0",
+                        "type": "string",
+                        "example": "prod",
+                        "default": "dev",
+                    },
+                    "athena_output_bucket": {
+                        "description": (
+                            "S3 bucket for Athena query results. Falls back to "
+                            "`overture-bundle-inspector-athena-output-<environment>` if unset."
+                        ),
+                        "version_added": "0.7.0",
+                        "type": "string",
+                        "example": "my-athena-output-bucket",
+                        "default": None,
+                    },
+                    "user": {
+                        "description": (
+                            "Namespace prefix under the bucket, read only when `environment` "
+                            "is `dev`."
+                        ),
+                        "version_added": "0.7.0",
+                        "type": "string",
+                        "example": "alice",
+                        "default": None,
+                    },
+                },
+            }
+        },
         "integrations": [
             {
                 "integration-name": "AWS Glue",

--- a/src/overture_airflow_provider/provider_info.py
+++ b/src/overture_airflow_provider/provider_info.py
@@ -40,6 +40,12 @@ def get_provider_info() -> dict:
             "overture_airflow_provider.links.SparkJobLink",
             "overture_airflow_provider.links.ReportIssueLink",
         ],
+        "plugins": [
+            {
+                "name": "bundle_inspector",
+                "plugin-class": "overture_airflow_provider.plugins.bundle_inspector.BundleInspectorPlugin",
+            }
+        ],
         "integrations": [
             {
                 "integration-name": "AWS Glue",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -55,6 +55,27 @@ docker compose --profile manual up --build standalone
 # http://localhost:8080  (airflow standalone prints the admin password)
 ```
 
+Always pass `--build` here, not just on first run: this service shares the same
+image as `e2e`, and a stale cached image silently skips out on source changes
+(entry points, plugin registration) between runs.
+
+To browse real data in the Bundle Inspector plugin (Browse -> Bundle
+Inspector), set its `s3_bucket` before bringing the container up, e.g.:
+
+```bash
+AIRFLOW__BUNDLE_INSPECTOR__S3_BUCKET=overturemaps-us-west-2 \
+  docker compose --profile manual up --build standalone
+```
+
+> [!NOTE]
+> The plugin's S3 client (`boto3.client("s3")`) signs every request, so it
+> needs real AWS credentials in the container even for a public bucket like
+> `overturemaps-us-west-2`: mount `~/.aws` (`-v ~/.aws:/home/airflow/.aws:ro`)
+> or pass `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Without credentials,
+> `/bundle-inspector/` still loads and `/api/bundle-inspector/config` still
+> resolves the bucket name; listing objects fails with
+> `botocore.exceptions.NoCredentialsError`.
+
 ## Collection gating
 
 `tests/e2e` is excluded from the default `pytest` run (the root `conftest.py`

--- a/tests/e2e/docker-compose.yaml
+++ b/tests/e2e/docker-compose.yaml
@@ -42,9 +42,7 @@ services:
   standalone:
     build: *build
     profiles: [manual]
-    environment:
-      <<: *airflow-env
-      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    environment: *airflow-env
     ports:
       - "8080:8080"
     command: ["bash", "-c", "airflow db migrate && airflow standalone"]

--- a/tests/test_bundle_inspector_endpoints.py
+++ b/tests/test_bundle_inspector_endpoints.py
@@ -1,9 +1,9 @@
 """Tests for the bundle inspector's framework-agnostic endpoint logic.
 
 Airflow-free at the seams that matter: monkeypatches
-``overture_airflow_provider._airflow_compat.Variable`` (imported into
-``_endpoints`` by name) rather than reading real Airflow Variables, and stubs
-out the boto3 S3 client, so it runs under the lightweight test venv.
+``airflow.configuration.conf`` (imported into ``_endpoints`` by name) rather
+than reading real ``airflow.cfg``, and stubs out the boto3 S3 client, so it
+runs under the lightweight test venv.
 """
 
 from datetime import UTC, datetime
@@ -13,14 +13,18 @@ import pytest
 from overture_airflow_provider.plugins.bundle_inspector import _endpoints as ep
 
 
-class _FakeVariable:
-    """Stand-in for ``overture_airflow_provider._airflow_compat.Variable``."""
+class _FakeConf:
+    """Stand-in for ``airflow.configuration.conf``, keyed by ``(section, key)``."""
 
     def __init__(self, values: dict):
         self._values = values
 
-    def get(self, key, default_var=None):
-        return self._values.get(key, default_var)
+    def get(self, section, key, fallback=None):
+        return self._values.get((section, key), fallback)
+
+
+def _conf(**bundle_inspector_options):
+    return _FakeConf({("bundle_inspector", k): v for k, v in bundle_inspector_options.items()})
 
 
 @pytest.fixture(autouse=True)
@@ -33,7 +37,7 @@ def _clear_s3_client_cache():
 
 class TestGetConfig:
     def test_defaults_to_dev_with_no_namespace(self, monkeypatch):
-        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b"))
         cfg = ep.get_config()
         assert cfg == {
             "bucket": "b",
@@ -43,37 +47,25 @@ class TestGetConfig:
             "namespace_prefix": "",
         }
 
-    def test_dev_reads_namespace_from_variable(self, monkeypatch):
-        monkeypatch.setattr(
-            ep,
-            "Variable",
-            _FakeVariable({"bundle_inspector_s3_bucket": "b", "bundle_inspector_user": "alice"}),
-        )
+    def test_missing_bucket_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(ep, "conf", _conf())
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.get_config()
+        assert exc_info.value.status == 500
+
+    def test_dev_reads_namespace_from_conf(self, monkeypatch):
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b", user="alice"))
         cfg = ep.get_config()
         assert cfg["namespace"] == "alice"
         assert cfg["namespace_prefix"] == "alice/"
 
-    def test_user_override_wins_over_variable(self, monkeypatch):
-        monkeypatch.setattr(
-            ep,
-            "Variable",
-            _FakeVariable({"bundle_inspector_s3_bucket": "b", "bundle_inspector_user": "alice"}),
-        )
+    def test_user_override_wins_over_conf(self, monkeypatch):
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b", user="alice"))
         cfg = ep.get_config(user_override="bob")
         assert cfg["namespace"] == "bob"
 
     def test_non_dev_ignores_namespace(self, monkeypatch):
-        monkeypatch.setattr(
-            ep,
-            "Variable",
-            _FakeVariable(
-                {
-                    "bundle_inspector_s3_bucket": "b",
-                    "bundle_inspector_environment": "prod",
-                    "bundle_inspector_user": "alice",
-                }
-            ),
-        )
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b", environment="prod", user="alice"))
         cfg = ep.get_config(user_override="bob")
         assert cfg["namespace"] == ""
         assert cfg["namespace_prefix"] == ""
@@ -81,7 +73,7 @@ class TestGetConfig:
 
 class TestListChildren:
     def test_root_returns_known_stages_without_s3_call(self, monkeypatch):
-        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b"))
         monkeypatch.setattr(
             ep,
             "_s3_client",
@@ -96,7 +88,7 @@ class TestListChildren:
         }
 
     def test_non_root_lists_and_filters_via_s3(self, monkeypatch):
-        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b"))
 
         class _FakeClient:
             def get_paginator(self, name):
@@ -145,7 +137,7 @@ class TestS3Proxy:
         assert exc_info.value.status == 400
 
     def test_allowed_suffix_reaches_s3(self, monkeypatch):
-        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b"))
 
         class _FakeClient:
             def head_object(self, **kwargs):
@@ -164,16 +156,7 @@ class TestAthenaQuery:
         assert exc_info.value.status == 400
 
     def test_uses_configured_output_bucket(self, monkeypatch):
-        monkeypatch.setattr(
-            ep,
-            "Variable",
-            _FakeVariable(
-                {
-                    "bundle_inspector_s3_bucket": "b",
-                    "bundle_inspector_athena_output_bucket": "athena-out",
-                }
-            ),
-        )
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b", athena_output_bucket="athena-out"))
         captured = {}
 
         def fake_athena_start(output_bucket, sql):
@@ -186,7 +169,7 @@ class TestAthenaQuery:
         assert captured["output_bucket"] == "athena-out"
 
     def test_falls_back_to_default_output_bucket(self, monkeypatch):
-        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b"))
         captured = {}
 
         def fake_athena_start(output_bucket, sql):
@@ -198,7 +181,7 @@ class TestAthenaQuery:
         assert captured["output_bucket"] == "overture-bundle-inspector-athena-output-dev"
 
     def test_error_result_raises_api_error(self, monkeypatch):
-        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep, "conf", _conf(s3_bucket="b"))
         monkeypatch.setattr(ep.s3, "athena_start", lambda output_bucket, sql: {"error": "boom"})
         with pytest.raises(ep.ApiError) as exc_info:
             ep.athena_query(sql="select 1", user=None)

--- a/tests/test_bundle_inspector_endpoints.py
+++ b/tests/test_bundle_inspector_endpoints.py
@@ -1,0 +1,220 @@
+"""Tests for the bundle inspector's framework-agnostic endpoint logic.
+
+Airflow-free at the seams that matter: monkeypatches
+``overture_airflow_provider._airflow_compat.Variable`` (imported into
+``_endpoints`` by name) rather than reading real Airflow Variables, and stubs
+out the boto3 S3 client, so it runs under the lightweight test venv.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from overture_airflow_provider.plugins.bundle_inspector import _endpoints as ep
+
+
+class _FakeVariable:
+    """Stand-in for ``overture_airflow_provider._airflow_compat.Variable``."""
+
+    def __init__(self, values: dict):
+        self._values = values
+
+    def get(self, key, default_var=None):
+        return self._values.get(key, default_var)
+
+
+@pytest.fixture(autouse=True)
+def _clear_s3_client_cache():
+    # `_s3_client` is `lru_cache`d; drop any stale fake client between tests.
+    ep._s3_client.cache_clear()
+    yield
+    ep._s3_client.cache_clear()
+
+
+class TestGetConfig:
+    def test_defaults_to_dev_with_no_namespace(self, monkeypatch):
+        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        cfg = ep.get_config()
+        assert cfg == {
+            "bucket": "b",
+            "athena_output_bucket": None,
+            "environment": "dev",
+            "namespace": "",
+            "namespace_prefix": "",
+        }
+
+    def test_dev_reads_namespace_from_variable(self, monkeypatch):
+        monkeypatch.setattr(
+            ep,
+            "Variable",
+            _FakeVariable({"bundle_inspector_s3_bucket": "b", "bundle_inspector_user": "alice"}),
+        )
+        cfg = ep.get_config()
+        assert cfg["namespace"] == "alice"
+        assert cfg["namespace_prefix"] == "alice/"
+
+    def test_user_override_wins_over_variable(self, monkeypatch):
+        monkeypatch.setattr(
+            ep,
+            "Variable",
+            _FakeVariable({"bundle_inspector_s3_bucket": "b", "bundle_inspector_user": "alice"}),
+        )
+        cfg = ep.get_config(user_override="bob")
+        assert cfg["namespace"] == "bob"
+
+    def test_non_dev_ignores_namespace(self, monkeypatch):
+        monkeypatch.setattr(
+            ep,
+            "Variable",
+            _FakeVariable(
+                {
+                    "bundle_inspector_s3_bucket": "b",
+                    "bundle_inspector_environment": "prod",
+                    "bundle_inspector_user": "alice",
+                }
+            ),
+        )
+        cfg = ep.get_config(user_override="bob")
+        assert cfg["namespace"] == ""
+        assert cfg["namespace_prefix"] == ""
+
+
+class TestListChildren:
+    def test_root_returns_known_stages_without_s3_call(self, monkeypatch):
+        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(
+            ep,
+            "_s3_client",
+            lambda: (_ for _ in ()).throw(AssertionError("should not call S3 at root")),
+        )
+        result = ep.list_children("", user=None)
+        assert result["depth"] == 0
+        assert {c["name"] for c in result["children"]} == {
+            "theme_promote/",
+            "theme_stage/",
+            "release_candidate/",
+        }
+
+    def test_non_root_lists_and_filters_via_s3(self, monkeypatch):
+        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+
+        class _FakeClient:
+            def get_paginator(self, name):
+                class _P:
+                    def paginate(self, **kwargs):
+                        yield {
+                            "CommonPrefixes": [{"Prefix": "theme_promote/theme=places/"}],
+                            "Contents": [
+                                {
+                                    "Key": "theme_promote/success",
+                                    "Size": 0,
+                                    "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+                                }
+                            ],
+                        }
+
+                return _P()
+
+        monkeypatch.setattr(ep, "_s3_client", lambda: _FakeClient())
+        result = ep.list_children("theme_promote/", user=None)
+        assert result["stage"] == "theme_promote"
+        assert result["hierarchy"] == ["theme", "schema", "run"]
+        names = {c["name"] for c in result["children"]}
+        assert "theme=places/" in names
+
+
+class TestS3Proxy:
+    def test_missing_key_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.s3proxy(key="", user=None, range_header=None, head_only=False)
+        assert exc_info.value.status == 400
+
+    def test_path_traversal_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.s3proxy(key="../secret.parquet", user=None, range_header=None, head_only=False)
+        assert exc_info.value.status == 400
+
+    def test_absolute_path_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.s3proxy(key="/etc/passwd.parquet", user=None, range_header=None, head_only=False)
+        assert exc_info.value.status == 400
+
+    def test_disallowed_suffix_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.s3proxy(key="file.exe", user=None, range_header=None, head_only=False)
+        assert exc_info.value.status == 400
+
+    def test_allowed_suffix_reaches_s3(self, monkeypatch):
+        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+
+        class _FakeClient:
+            def head_object(self, **kwargs):
+                return {"ContentType": "application/octet-stream", "ContentLength": 123}
+
+        monkeypatch.setattr(ep, "_s3_client", lambda: _FakeClient())
+        result = ep.s3proxy(key="a/b.parquet", user=None, range_header=None, head_only=True)
+        assert result.status == 200
+        assert result.headers["Content-Length"] == "123"
+
+
+class TestAthenaQuery:
+    def test_missing_sql_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.athena_query(sql="", user=None)
+        assert exc_info.value.status == 400
+
+    def test_uses_configured_output_bucket(self, monkeypatch):
+        monkeypatch.setattr(
+            ep,
+            "Variable",
+            _FakeVariable(
+                {
+                    "bundle_inspector_s3_bucket": "b",
+                    "bundle_inspector_athena_output_bucket": "athena-out",
+                }
+            ),
+        )
+        captured = {}
+
+        def fake_athena_start(output_bucket, sql):
+            captured["output_bucket"] = output_bucket
+            return {"query_id": "abc"}
+
+        monkeypatch.setattr(ep.s3, "athena_start", fake_athena_start)
+        result = ep.athena_query(sql="select 1", user=None)
+        assert result == {"query_id": "abc"}
+        assert captured["output_bucket"] == "athena-out"
+
+    def test_falls_back_to_default_output_bucket(self, monkeypatch):
+        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        captured = {}
+
+        def fake_athena_start(output_bucket, sql):
+            captured["output_bucket"] = output_bucket
+            return {"query_id": "abc"}
+
+        monkeypatch.setattr(ep.s3, "athena_start", fake_athena_start)
+        ep.athena_query(sql="select 1", user=None)
+        assert captured["output_bucket"] == "overture-bundle-inspector-athena-output-dev"
+
+    def test_error_result_raises_api_error(self, monkeypatch):
+        monkeypatch.setattr(ep, "Variable", _FakeVariable({"bundle_inspector_s3_bucket": "b"}))
+        monkeypatch.setattr(ep.s3, "athena_start", lambda output_bucket, sql: {"error": "boom"})
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep.athena_query(sql="select 1", user=None)
+        assert exc_info.value.status == 400
+
+
+class TestValidateQueryId:
+    def test_missing_query_id_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep._validate_query_id("")
+        assert exc_info.value.status == 400
+
+    def test_malformed_query_id_is_rejected(self):
+        with pytest.raises(ep.ApiError) as exc_info:
+            ep._validate_query_id("not-a-uuid")
+        assert exc_info.value.status == 400
+
+    def test_valid_uuid_passes(self):
+        ep._validate_query_id("12345678-1234-1234-1234-123456789abc")

--- a/tests/test_bundle_inspector_s3.py
+++ b/tests/test_bundle_inspector_s3.py
@@ -1,0 +1,184 @@
+"""Tests for the bundle inspector's S3 listing/filtering helpers.
+
+Airflow-free and boto3-free: exercises pure logic and a fake paginator-based
+S3 client, so it runs under the lightweight test venv.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from overture_airflow_provider.plugins.bundle_inspector import s3
+
+
+class _FakePaginator:
+    """Fake boto3 paginator that replays canned pages regardless of kwargs."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        yield from self._pages
+
+
+class _FakeClient:
+    """Fake boto3 S3 client backed by canned `list_objects_v2` pages."""
+
+    def __init__(self, pages):
+        self._pages = pages
+
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        return _FakePaginator(self._pages)
+
+
+class TestDepthAndHierarchy:
+    def test_get_depth_root(self):
+        assert s3.get_depth("") == 0
+
+    def test_get_depth_nested(self):
+        assert s3.get_depth("theme_promote/theme=places/") == 2
+
+    def test_hierarchy_for_known_stage(self):
+        assert s3.hierarchy_for_stage("theme_promote") == ["theme", "schema", "run"]
+
+    def test_hierarchy_falls_back_to_default(self):
+        assert s3.hierarchy_for_stage("unknown_stage") == s3.DEFAULT_HIERARCHY
+
+    def test_run_depth_for_stage(self):
+        # theme_promote: ["theme", "schema", "run"] -> run at index 2 -> depth 4
+        assert s3.run_depth_for_stage("theme_promote") == 4
+
+    def test_run_depth_falls_back_when_no_run_level(self):
+        s3.STAGE_HIERARCHY["_no_run"] = ["theme"]
+        try:
+            assert s3.run_depth_for_stage("_no_run") == 2
+        finally:
+            del s3.STAGE_HIERARCHY["_no_run"]
+
+
+class TestFilterBundleLevel:
+    def test_filters_hive_partition_level(self):
+        items = [
+            {"name": "theme=places/", "type": "directory"},
+            {"name": "not-hive/", "type": "directory"},
+        ]
+        filtered = s3.filter_bundle_level(items, "theme_promote", 0)
+        assert filtered == [items[0]]
+
+    def test_component_level_applies_allowlist(self):
+        items = [
+            {"name": "data/", "type": "directory"},
+            {"name": "junk/", "type": "directory"},
+            {"name": "success", "type": "file"},
+        ]
+        filtered = s3.filter_bundle_level(items, "theme_stage", 2)
+        names = {item["name"] for item in filtered}
+        assert names == {"data/", "success"}
+
+    def test_negative_depth_passes_through(self):
+        items = [{"name": "anything/", "type": "directory"}]
+        assert s3.filter_bundle_level(items, "theme_promote", -1) == items
+
+    def test_no_allowlist_passes_through_at_leaf(self):
+        items = [{"name": "whatever/", "type": "directory"}]
+        # theme_promote has no STAGE_COMPONENTS entry, so leaf level passes through
+        assert s3.filter_bundle_level(items, "theme_promote", 3) == items
+
+
+class TestListPrefix:
+    def test_splits_directories_and_files(self):
+        pages = [
+            {
+                "CommonPrefixes": [{"Prefix": "ns/theme_promote/theme=places/"}],
+                "Contents": [
+                    {
+                        "Key": "ns/theme_promote/metadata.json",
+                        "Size": 42,
+                        "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+                    },
+                    # Exact-prefix match (no name) must be skipped.
+                    {
+                        "Key": "ns/theme_promote/",
+                        "Size": 0,
+                        "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
+                    },
+                ],
+            }
+        ]
+        client = _FakeClient(pages)
+        items = s3.list_prefix(client, "bucket", "ns/theme_promote/")
+        assert items == [
+            {"name": "theme=places/", "type": "directory"},
+            {
+                "name": "metadata.json",
+                "type": "file",
+                "size": 42,
+                "last_modified": "2024-01-01T00:00:00+00:00",
+            },
+        ]
+
+
+class TestListUsers:
+    def test_lists_top_level_prefixes(self):
+        pages = [{"CommonPrefixes": [{"Prefix": "alice/"}, {"Prefix": "bob/"}]}]
+        client = _FakeClient(pages)
+        assert s3.list_users(client, "bucket") == ["alice", "bob"]
+
+
+class TestCountObjects:
+    def test_sums_key_count_across_pages(self):
+        pages = [{"KeyCount": 3}, {"KeyCount": 2}]
+        client = _FakeClient(pages)
+        assert s3.count_objects(client, "bucket", "ns/") == 5
+
+
+class TestListTree:
+    def test_builds_nested_tree_and_truncates_files(self):
+        pages = [
+            {
+                "Contents": [
+                    {"Key": "ns/a/1.parquet"},
+                    {"Key": "ns/a/2.parquet"},
+                    {"Key": "ns/a/3.parquet"},
+                    {"Key": "ns/a/4.parquet"},
+                    {"Key": "ns/b/only.json"},
+                ]
+            }
+        ]
+        client = _FakeClient(pages)
+        tree = s3.list_tree(client, "bucket", "ns/", max_files_per_dir=2)
+        assert tree["dirs"]["a"]["files"] == ["1.parquet", "2.parquet"]
+        assert tree["dirs"]["a"]["_omitted"] == 2
+        assert tree["dirs"]["b"]["files"] == ["only.json"]
+        assert "_omitted" not in tree["dirs"]["b"]
+        assert tree["_total_keys"] == 5
+        assert tree["_truncated"] is False
+
+
+class TestFindAndPresignFile:
+    def test_find_file_key_matches_suffix(self):
+        pages = [{"Contents": [{"Key": "ns/a.txt"}, {"Key": "ns/b.parquet"}]}]
+        client = _FakeClient(pages)
+        assert s3.find_file_key(client, "bucket", "ns/", ".parquet") == "ns/b.parquet"
+
+    def test_find_file_key_no_match_returns_none(self):
+        client = _FakeClient([{"Contents": [{"Key": "ns/a.txt"}]}])
+        assert s3.find_file_key(client, "bucket", "ns/", ".parquet") is None
+
+    def test_presign_file_returns_none_when_no_match(self):
+        client = _FakeClient([{"Contents": []}])
+        assert s3.presign_file(client, "bucket", "ns/", ".parquet") is None
+
+
+class TestParseS3Uri:
+    def test_parses_bucket_and_key(self):
+        assert s3._parse_s3_uri("s3://my-bucket/some/key.csv") == ("my-bucket", "some/key.csv")
+
+    def test_rejects_non_s3_uri(self):
+        with pytest.raises(ValueError):
+            s3._parse_s3_uri("https://example.com/key.csv")
+
+    def test_rejects_missing_key(self):
+        with pytest.raises(ValueError):
+            s3._parse_s3_uri("s3://my-bucket")


### PR DESCRIPTION
Ports the `bundle_inspector` Airflow plugin from `tf-data-platform` into this package as an entry-point-discovered plugin, closes #68. It's a Browse -> Bundle Inspector UI for walking pipeline stages, themes, schema versions, and run IDs directly in S3, plus GeoParquet/PMTiles preview and ad hoc Athena queries against the same bundle.

### Framework adapters

Airflow 2 and 3 use fundamentally different plugin APIs (Flask blueprints + FAB menu items vs FastAPI apps + external views), so the port splits into a framework-agnostic `_endpoints.py` core and two thin adapters (`flask_app.py`, `fastapi_app.py`). `__init__.py` picks the right one via `AIRFLOW_MAJOR` and degrades to an empty plugin (with a warning log) if the framework or Airflow's FastAPI auth dependency is missing, rather than breaking plugin loading entirely.

> [!NOTE]
> `fastapi_app.py`'s use of `airflow.api_fastapi.core_api.security.GetUserDep` authorizes any authenticated Airflow user rather than a per-DAG check, since bundle browsing isn't scoped to a single `dag_id` the way Airflow 2's `has_access_dag` expects. Flagged in the module docstring as the area most likely to shift across Airflow 3.x point releases.

### Config

Config lives in a `[bundle_inspector]` `airflow.cfg` section (`s3_bucket`, `environment`, `athena_output_bucket`, `user`), registered via `provider_info.py`'s `config` key and read through `airflow.configuration.conf`. That's a better fit than Airflow Variables for deployment-time settings: `conf` gets a free `AIRFLOW__BUNDLE_INSPECTOR__<OPTION>` env var override per option, shows up in `airflow config list`/the Configuration UI page with its description and default, and doesn't round-trip the metadata DB on every request the way `Variable.get` does. GeoParquet preview needs `pyarrow` and `shapely`, so those land in a new `bundle-inspector` extra instead of core dependencies.

### Dropped: `/register-table`

`tf-data-platform`'s `/register-table` endpoint depended on its internal DAG naming and a private `table_registry` module with no equivalent here, so it doesn't carry over.

## Testing

Added `tests/test_bundle_inspector_s3.py` and `tests/test_bundle_inspector_endpoints.py` (38 tests) covering the S3 listing/filtering helpers and the framework-agnostic endpoint logic, mocking `boto3` and `airflow.configuration.conf` so they run without Flask or FastAPI installed.

`uv run ruff check`/`format` pass on all new and touched files.

Couldn't run the existing suite or these new tests through `uv run pytest` on this machine: the installed Airflow 3.3.0 build fails to import `airflow.sdk` on Windows (`os.register_at_fork`, a POSIX-only attribute), and that's true on `main` too, unrelated to this change. I verified the new tests directly with `pytest` after stubbing just `airflow.plugins_manager.AirflowPlugin` and `_airflow_compat.AIRFLOW_MAJOR`, which sidesteps that Windows import chain: all 38 pass, plus `test_version.py` after the version bump.

The Airflow 3 FastAPI adapter (`fastapi_app.py`) is unverified against a real Airflow process, since `airflow.api_fastapi.core_api.security` sits behind the same broken Windows import chain. It needs the Linux e2e container or a real Airflow 3 deploy to exercise.