### PR TITLE
[BUG] Surface bundle_inspector Athena errors immediately instead of hanging until timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,10 +101,28 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: docker compose run --rm --build e2e
 
-  all-pass:
-    name: All pytest versions passed
+  node-test:
+    name: node --test (bundle_inspector JS)
     runs-on: ubuntu-slim
-    needs: [pytest, pytest-airflow2, e2e]
+    permissions:
+      contents: read  # checkout only
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Run node --test
+        run: node --test
+
+  all-pass:
+    name: All tests passed
+    runs-on: ubuntu-slim
+    needs: [pytest, pytest-airflow2, e2e, node-test]
     if: always()
     steps:
       - uses: lowlydba/are-we-good@4b62765391e357e78d0572113ab8b1c7d6b8d12a # v1.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-10
+
+### Fixed
+
+- **`bundle_inspector`: Athena query polling hangs on error responses instead
+  of surfacing them.** `fetchAthenaQuery`'s poll loop only exited on
+  `status.state` of `SUCCEEDED`, `FAILED`, or `CANCELLED`. When
+  `athena-status` returned a non-2xx error (e.g. `TABLE_NOT_FOUND` for a
+  query against an unregistered table), the body has no `state`, so the loop
+  polled every second for the full 5-minute timeout showing `undefined...`
+  instead of the real error.
+  ([#70](https://github.com/OvertureMaps/overture-airflow-provider/issues/70))
+
 ## [0.7.0] - 2026-08-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ uv run pytest -v                 # run the test suite
 uv run ruff check .              # lint (includes Airflow AIR* rules)
 uv run ruff format --check .     # format check
 uv run ruff format .             # apply formatting
+node --test                      # run bundle_inspector's static JS tests (no deps, Node's built-in runner)
 ```
 
 ## PR title format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.7.0"
+version = "0.7.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/core.js
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/static/bundle_inspector/core.js
@@ -153,6 +153,7 @@ async function fetchAthenaQuery(sql, onStatus) {
 
     while (Date.now() < deadline) {
         const status = await fetchAthenaStatus(queryId);
+        if (status.error) return status;
         if (onStatus) onStatus(status.state);
         if (status.state === 'SUCCEEDED') return status;
         if (status.state === 'FAILED' || status.state === 'CANCELLED') return status;

--- a/tests/js/bundle_inspector_core.test.mjs
+++ b/tests/js/bundle_inspector_core.test.mjs
@@ -1,0 +1,88 @@
+// Lightweight unit tests for the bundle_inspector static JS, using Node's
+// built-in test runner and `vm` module instead of pulling in a JS test
+// framework/dependency. Run with: node --test
+//
+// core.js is a plain browser script (no module exports), so it's loaded into
+// a vm context with the minimal DOM/fetch surface it touches at call time.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CORE_JS_PATH = path.join(
+    __dirname,
+    '..',
+    '..',
+    'src',
+    'overture_airflow_provider',
+    'plugins',
+    'bundle_inspector',
+    'static',
+    'bundle_inspector',
+    'core.js',
+);
+const source = fs.readFileSync(CORE_JS_PATH, 'utf8');
+
+/**
+ * Loads core.js into a fresh vm context, stubbing `fetch` to return each
+ * response in `responses` in order (one per call).
+ */
+function loadCore(responses) {
+    let call = 0;
+    const sandbox = {
+        fetch: async () => {
+            const body = responses[call];
+            call += 1;
+            return {
+                ok: !body.error,
+                status: body.error ? 400 : 200,
+                json: async () => body,
+            };
+        },
+        document: { createElement: () => ({}) },
+        window: { location: { pathname: '/' } },
+        history: { replaceState: () => {} },
+        btoa: (s) => Buffer.from(s).toString('base64'),
+        CSS: { escape: (s) => s },
+        URLSearchParams,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox);
+    return sandbox;
+}
+
+test('fetchAthenaQuery returns the error immediately when a poll response has no state (regression for #70)', async () => {
+    const sandbox = loadCore([
+        { query_id: 'abc123' }, // athena-query start
+        { error: "TABLE_NOT_FOUND: line 1:15: Table 'awsdatacatalog.db.t' does not exist" }, // athena-status poll
+    ]);
+
+    const result = await sandbox.fetchAthenaQuery('select 1');
+
+    assert.deepEqual(result, {
+        error: "TABLE_NOT_FOUND: line 1:15: Table 'awsdatacatalog.db.t' does not exist",
+    });
+});
+
+test('fetchAthenaQuery returns immediately when athena-query start itself errors', async () => {
+    const sandbox = loadCore([{ error: 'INVALID_SQL: syntax error' }]);
+
+    const result = await sandbox.fetchAthenaQuery('not sql');
+
+    assert.deepEqual(result, { error: 'INVALID_SQL: syntax error' });
+});
+
+test('fetchAthenaQuery returns the SUCCEEDED status on the happy path', async () => {
+    const sandbox = loadCore([
+        { query_id: 'abc123' },
+        { state: 'SUCCEEDED', rows: [[1]] },
+    ]);
+
+    const result = await sandbox.fetchAthenaQuery('select 1');
+
+    assert.deepEqual(result, { state: 'SUCCEEDED', rows: [[1]] });
+});


### PR DESCRIPTION
`fetchAthenaQuery`'s poll loop in `core.js` only exits on `status.state === 'SUCCEEDED'/'FAILED'/'CANCELLED'`. When `athena-status` returns a non-2xx error (e.g. `TABLE_NOT_FOUND` for a query against an unregistered table), the body is `{"error": "..."}` with no `state`, so `status.state` is `undefined` and neither exit condition matches. The loop polls every second for the full 5-minute `TIMEOUT`, showing `undefined...` the whole time before finally reporting a generic timeout instead of the real error.

Fixes #70. Add a `status.error` check at the top of the loop, mirroring the existing `start.error` short-circuit in the same function, so an error response returns immediately.

There was no JS test harness for `bundle_inspector`'s static assets, so this adds one: `tests/js/bundle_inspector_core.test.mjs` uses Node's built-in `node:test` runner and `vm` to load `core.js` with a stubbed `fetch`, no new dependency. Run it with `node --test`.

## Testing

`node --test` covers the regression (`fetchAthenaStatus` returning `{error}` mid-poll), the existing `start.error` short-circuit, and the `SUCCEEDED` happy path.