### PR TITLE
[BUG] Surface glue terminal failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-17
+
+### Added
+
+- **`GlueConfig.output_log_group`, so a consumer whose jobs write continuous
+  logging output to a non-default group can still get the CloudWatch
+  fallback below.** The CloudWatch output log group backing that fallback
+  was hardcoded to AWS's own `/aws-glue/jobs/output`. Defaults to that same
+  value; override it via `GlueConfig` when your jobs are configured
+  otherwise.
+
 ### Fixed
 
 - **Deferred Glue job failures surfaced as a generic "trigger/polling failure"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deferred Glue job failures surfaced as a generic "trigger/polling failure"
+  instead of the real error.** The AWS Glue trigger raises on a terminal
+  FAILED/STOPPED/TIMEOUT state rather than emitting a completion event, so a
+  finished-but-failed run reaches `resume_execution` as a `__fail__` and was
+  classified as a Triggerer crash: the task log showed
+  `Spark job FAILED on GLUE (trigger/polling failure ...) run: <unknown>`
+  while the actual Glue `ErrorMessage` stayed only in CloudWatch.
+  `resume_execution` now recovers the run id from the trigger error and
+  resolves it through the same `complete_job` path `execute_complete` uses, so
+  the task log names the real platform error with the run id. Genuine
+  Triggerer crashes (no resolvable run) keep the trigger-failure
+  classification.
+
 ## [0.7.1] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **Deferred Glue job failures surfaced as a generic "trigger/polling failure"
-  instead of the real error.** The AWS Glue trigger raises on a terminal
-  FAILED/STOPPED/TIMEOUT state rather than emitting a completion event, so a
-  finished-but-failed run reaches `resume_execution` as a `__fail__` and was
+  where the real error belonged.** The AWS Glue trigger raises on a terminal
+  FAILED/STOPPED/TIMEOUT state, and a raising trigger reaches
+  `resume_execution` as a `__fail__`, so a finished-but-failed run was
   classified as a Triggerer crash: the task log showed
   `Spark job FAILED on GLUE (trigger/polling failure ...) run: <unknown>`
   while the actual Glue `ErrorMessage` stayed only in CloudWatch.
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the task log names the real platform error with the run id. Genuine
   Triggerer crashes (no resolvable run) keep the trigger-failure
   classification.
+
+- **Glue failure messages carried only a one-line `ErrorMessage`, even though
+  the job's own diagnostics (e.g. a validation job's full multi-line error
+  report) were sitting in CloudWatch the whole time.** Glue's `JobRun.LogTail`
+  field, meant to carry a stderr tail, is empty for GlueVersion 5.0 Spark
+  jobs, so `describe_failure`'s root-cause line was always blank for Glue.
+  `complete_glue_job` now falls back to the run's own CloudWatch output log
+  stream (deterministically named after the run id) when `LogTail` is empty,
+  so the full report reaches the task log's `cause:` line. A fetch failure
+  (missing stream, permissions, throttling) is swallowed and simply omits the
+  cause line rather than breaking failure reporting.
 
 ## [0.7.1] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   diagnostics now go through a module logger (`debug`/`warning`), filterable
   by log level.
 
+- **A resolved terminal Glue failure re-raised as the retryable
+  `AirflowException`, letting a caller-configured retry resubmit a job that
+  already ran to a real failure.** `resume_execution`'s recovered-run-id path
+  reaches `complete_job` only once a run id is confirmed, i.e. the job
+  launched, but `complete_job` only ever raises plain `AirflowException`. That
+  plain exception is now converted to the non-retryable `AirflowFailException`,
+  matching the same launched-and-failed reasoning `execute()` already applies.
+
 ## [0.7.1] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `complete_glue_job` now falls back to the run's own CloudWatch output log
   stream (deterministically named after the run id) when `LogTail` is empty,
   so the full report reaches the task log's `cause:` line. A fetch failure
-  (missing stream, permissions, throttling) is swallowed and simply omits the
-  cause line rather than breaking failure reporting.
+  (missing stream, permissions, throttling) is swallowed, so the message
+  just omits the cause line and failure reporting stays intact.
+
+- **The CloudWatch fallback above could itself return a truncated tail that
+  cuts off right where the job's real failure report begins.** `GetLogEvents`
+  can hand back a stale, partial view of a stream for a while after a run
+  finishes. `_fetch_glue_output_log_tail` now polls a few times, watching for
+  the line Glue's driver prints right before exiting, as proof the stream has
+  nothing left to deliver. A freshly-completed stream can also hand every
+  event back on the first call out of timestamp order, so the fetch now
+  sorts events before joining them.
+
+- **Three Copilot review findings on the above.** A run id that lives only in
+  `error` is now checked alongside `traceback`. A malformed CloudWatch event
+  missing `timestamp`/`message` is now handled gracefully, keeping the
+  "returns `None` on any failure" contract intact. The log-tail fetch's
+  diagnostics now go through a module logger (`debug`/`warning`), filterable
+  by log level.
 
 ## [0.7.1] - 2026-08-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.7.1"
+version = "0.7.2"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_glue.py
+++ b/src/overture_airflow_provider/_glue.py
@@ -1,13 +1,18 @@
 """AWS Glue execution: Python package + JAR caching, job submission."""
 
 import json
+import logging
 import shutil
+import time
+from collections.abc import Callable
 
 import boto3
 
 from overture_airflow_provider.cluster_sizing import AwsGlueClusterSize
 from overture_airflow_provider.spark import SparkSedona
 from overture_airflow_provider.spark_agnostic_helpers import SparkAgnosticHelper
+
+_log = logging.getLogger(__name__)
 
 MAX_TIMEOUT_HOURS = 8
 
@@ -467,34 +472,92 @@ def submit_glue_job(
 
 
 _GLUE_OUTPUT_LOG_GROUP = "/aws-glue/jobs/output"
+#: Glue's driver prints this immediately before exiting, on every job run
+#: regardless of the job's own code. Its presence means the stream has
+#: nothing left to deliver.
+_GLUE_SHUTDOWN_MARKER = "Running autoDebugger shutdown hook."
+#: Bounds on how long the CloudWatch catch-up poll below can run.
+_LOG_TAIL_POLL_ATTEMPTS = 6
+_LOG_TAIL_POLL_INTERVAL_SECONDS = 4
+#: Logged with each diagnostic line below so a task log shows which version
+#: of this function's fetch/sort logic actually ran.
+_LOG_TAIL_FETCH_VERSION = "sort-v1"
 
 
 def _fetch_glue_output_log_tail(
-    region: str, run_id: str | None, max_events: int = 1000
+    region: str,
+    run_id: str | None,
+    max_events: int = 1000,
+    poll: bool = False,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> str | None:
-    """Best-effort fetch of the tail of a Glue job run's driver stdout.
+    """Best-effort fetch of a Glue job run's driver stdout tail.
 
-    Glue's own ``JobRun.LogTail`` field is not populated for GlueVersion 5.0
-    Spark jobs (confirmed against real runs). A job's own diagnostics, e.g. a
-    validation job's full multi-line error report printed via plain
-    ``print()``, live only in the run's CloudWatch output log stream, named
-    after the run id under ``/aws-glue/jobs/output``. Returns ``None`` on any
-    failure (stream not yet created, permissions, throttling), so an
-    enrichment failure here can never break failure reporting itself.
+    Glue's own ``JobRun.LogTail`` is empty for GlueVersion 5.0 Spark jobs, so
+    a job's own diagnostics (e.g. a validation job's error report) live only
+    in its CloudWatch output log stream, named after the run id.
+
+    ``GetLogEvents`` can return an incomplete or out-of-order view for a
+    while after a run finishes, even once the stream is done. ``poll=True``
+    retries until ``_GLUE_SHUTDOWN_MARKER`` shows up, proving the stream is
+    actually done; events are sorted by timestamp before joining regardless,
+    since order isn't guaranteed even once everything's arrived. Omitting
+    ``poll`` does a single fetch.
+
+    Returns ``None`` on any failure, so a fetch problem here can't break
+    failure reporting itself.
     """
     if not run_id:
         return None
     try:
         logs_client = boto3.client("logs", region_name=region)
-        response = logs_client.get_log_events(
-            logGroupName=_GLUE_OUTPUT_LOG_GROUP,
-            logStreamName=run_id,
-            startFromHead=False,
-            limit=max_events,
-        )
-        return "\n".join(e["message"] for e in response.get("events", [])) or None
     except Exception:
         return None
+
+    attempts = _LOG_TAIL_POLL_ATTEMPTS if poll else 1
+    events: list[dict] = []
+    for attempt in range(attempts):
+        try:
+            response = logs_client.get_log_events(
+                logGroupName=_GLUE_OUTPUT_LOG_GROUP,
+                logStreamName=run_id,
+                startFromHead=False,
+                limit=max_events,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log.warning(
+                "log-tail fetch attempt %d/%d for %s raised: %s",
+                attempt + 1,
+                attempts,
+                run_id,
+                exc,
+            )
+            break
+        events = sorted(response.get("events", []), key=lambda e: e.get("timestamp", 0))
+        complete = any(_GLUE_SHUTDOWN_MARKER in e.get("message", "") for e in events)
+        _log.debug(
+            "log-tail fetch [%s] attempt %d/%d for %s: %d events "
+            "(first_ts=%s, last_ts=%s), shutdown marker %s",
+            _LOG_TAIL_FETCH_VERSION,
+            attempt + 1,
+            attempts,
+            run_id,
+            len(events),
+            events[0].get("timestamp") if events else None,
+            events[-1].get("timestamp") if events else None,
+            "found" if complete else "not found",
+        )
+        if complete or attempt == attempts - 1:
+            break
+        sleep(_LOG_TAIL_POLL_INTERVAL_SECONDS)
+    tail = "\n".join(e.get("message", "") for e in events) or None
+    _log.debug(
+        "log-tail fetch [%s] returning %d chars for %s",
+        _LOG_TAIL_FETCH_VERSION,
+        len(tail) if tail else 0,
+        run_id,
+    )
+    return tail
 
 
 def complete_glue_job(setup_info: dict, run_id: str, context: dict, handler=None) -> dict:
@@ -520,7 +583,7 @@ def complete_glue_job(setup_info: dict, run_id: str, context: dict, handler=None
             from overture_airflow_provider._failures import format_failure
 
             if not job_run.get("LogTail"):
-                output_tail = _fetch_glue_output_log_tail(region, run_id)
+                output_tail = _fetch_glue_output_log_tail(region, run_id, poll=True)
                 if output_tail:
                     job_run = {**job_run, "LogTail": output_tail}
 

--- a/src/overture_airflow_provider/_glue.py
+++ b/src/overture_airflow_provider/_glue.py
@@ -466,13 +466,45 @@ def submit_glue_job(
     }
 
 
+_GLUE_OUTPUT_LOG_GROUP = "/aws-glue/jobs/output"
+
+
+def _fetch_glue_output_log_tail(
+    region: str, run_id: str | None, max_events: int = 1000
+) -> str | None:
+    """Best-effort fetch of the tail of a Glue job run's driver stdout.
+
+    Glue's own ``JobRun.LogTail`` field is not populated for GlueVersion 5.0
+    Spark jobs (confirmed against real runs). A job's own diagnostics, e.g. a
+    validation job's full multi-line error report printed via plain
+    ``print()``, live only in the run's CloudWatch output log stream, named
+    after the run id under ``/aws-glue/jobs/output``. Returns ``None`` on any
+    failure (stream not yet created, permissions, throttling), so an
+    enrichment failure here can never break failure reporting itself.
+    """
+    if not run_id:
+        return None
+    try:
+        logs_client = boto3.client("logs", region_name=region)
+        response = logs_client.get_log_events(
+            logGroupName=_GLUE_OUTPUT_LOG_GROUP,
+            logStreamName=run_id,
+            startFromHead=False,
+            limit=max_events,
+        )
+        return "\n".join(e["message"] for e in response.get("events", [])) or None
+    except Exception:
+        return None
+
+
 def complete_glue_job(setup_info: dict, run_id: str, context: dict, handler=None) -> dict:
     """Resolve a completed Glue run into the final result dict.
 
     Called from the deferrable operator's ``execute_complete`` after the
     ``GlueJobCompleteTrigger`` reports the run reached a terminal state. On a
     non-success state, ``handler`` (when supplied) is used to raise a classified,
-    de-noised failure naming the Glue ``ErrorMessage`` as the root cause.
+    de-noised failure naming the Glue ``ErrorMessage`` as the root cause, with the
+    run's own stdout tail attached when Glue's ``LogTail`` field is empty.
     """
     from overture_airflow_provider._airflow_compat import AirflowException
 
@@ -481,13 +513,19 @@ def complete_glue_job(setup_info: dict, run_id: str, context: dict, handler=None
     glue_client = boto3.client("glue", region_name=region)
 
     job_status = glue_client.get_job_run(JobName=job_name, RunId=run_id)
-    job_state = job_status["JobRun"]["JobRunState"]
+    job_run = job_status["JobRun"]
+    job_state = job_run["JobRunState"]
     if job_state != "SUCCEEDED":
         if handler is not None:
             from overture_airflow_provider._failures import format_failure
 
+            if not job_run.get("LogTail"):
+                output_tail = _fetch_glue_output_log_tail(region, run_id)
+                if output_tail:
+                    job_run = {**job_run, "LogTail": output_tail}
+
             failure = handler.describe_failure(
-                payload=job_status["JobRun"],
+                payload=job_run,
                 run_id=run_id,
                 run_launched=True,
                 console_url=_glue_console_url(region, job_name, run_id),

--- a/src/overture_airflow_provider/_glue.py
+++ b/src/overture_airflow_provider/_glue.py
@@ -471,6 +471,8 @@ def submit_glue_job(
     }
 
 
+#: AWS's own default continuous-logging output log group; see GlueConfig
+#: .output_log_group in config.py for how a consumer overrides this.
 _GLUE_OUTPUT_LOG_GROUP = "/aws-glue/jobs/output"
 #: Glue's driver prints this immediately before exiting, on every job run
 #: regardless of the job's own code. Its presence means the stream has
@@ -490,12 +492,16 @@ def _fetch_glue_output_log_tail(
     max_events: int = 1000,
     poll: bool = False,
     sleep: Callable[[float], None] = time.sleep,
+    log_group: str = _GLUE_OUTPUT_LOG_GROUP,
 ) -> str | None:
     """Best-effort fetch of a Glue job run's driver stdout tail.
 
     Glue's own ``JobRun.LogTail`` is empty for GlueVersion 5.0 Spark jobs, so
     a job's own diagnostics (e.g. a validation job's error report) live only
-    in its CloudWatch output log stream, named after the run id.
+    in its CloudWatch output log stream, named after the run id. ``log_group``
+    defaults to Glue's own log group but should be set from the consumer's
+    ``GlueConfig.output_log_group`` when a job writes continuous logging
+    output elsewhere.
 
     ``GetLogEvents`` can return an incomplete or out-of-order view for a
     while after a run finishes, even once the stream is done. ``poll=True``
@@ -519,7 +525,7 @@ def _fetch_glue_output_log_tail(
     for attempt in range(attempts):
         try:
             response = logs_client.get_log_events(
-                logGroupName=_GLUE_OUTPUT_LOG_GROUP,
+                logGroupName=log_group,
                 logStreamName=run_id,
                 startFromHead=False,
                 limit=max_events,
@@ -583,7 +589,10 @@ def complete_glue_job(setup_info: dict, run_id: str, context: dict, handler=None
             from overture_airflow_provider._failures import format_failure
 
             if not job_run.get("LogTail"):
-                output_tail = _fetch_glue_output_log_tail(region, run_id, poll=True)
+                log_group = setup_info.get("glue_output_log_group", _GLUE_OUTPUT_LOG_GROUP)
+                output_tail = _fetch_glue_output_log_tail(
+                    region, run_id, poll=True, log_group=log_group
+                )
                 if output_tail:
                     job_run = {**job_run, "LogTail": output_tail}
 

--- a/src/overture_airflow_provider/_operator.py
+++ b/src/overture_airflow_provider/_operator.py
@@ -43,15 +43,12 @@ _GLUE_RUN_ID_RE = re.compile(r"\bjr_[0-9a-f]{16,}\b")
 
 
 def _terminal_run_id(error_text: str) -> str | None:
-    """Recover a Glue run id from a trigger error that reports a terminal state.
+    """Recover a Glue run id from a trigger error reporting a terminal state.
 
-    The AWS Glue trigger raises ``... Job jr_<hex> Run State: FAILED`` (or
-    STOPPED/TIMEOUT) on a terminal state, so a finished-but-failed run reaches
-    ``resume_execution`` through the ``__fail__`` sentinel. A message that both
-    names a run and reports a run state is a resolvable terminal failure; a
-    genuine Triggerer crash (a connection drop mid-poll) carries neither, so it
-    returns ``None`` and the caller keeps the generic trigger-failure
-    classification.
+    The Glue trigger raises ``... Job jr_<hex> Run State: FAILED`` (or
+    STOPPED/TIMEOUT) on a terminal state. A message with both a run id and a
+    run state is resolvable; a genuine Triggerer crash carries neither, so
+    this returns ``None`` and the caller keeps the generic classification.
     """
     if "Run State" not in error_text:
         return None
@@ -198,31 +195,23 @@ class SparkAgnosticExecuteOperator(BaseOperator):
     def resume_execution(self, next_method, next_kwargs, context):
         """Enrich deferral/trigger (Triggerer) failures before they surface.
 
-        Airflow resumes a deferred task with the ``__fail__`` sentinel for
-        ``next_method`` in two distinct situations, and this method separates
-        them:
+        Airflow resumes a deferred task with the ``__fail__`` sentinel in two
+        cases:
 
         1. A finished job that reached a terminal non-success state. Some
-           provider triggers (notably AWS Glue) *raise* on a terminal FAILED /
-           STOPPED / TIMEOUT state, and a raising trigger reaches ``__fail__``.
-           That is a real, finished job failure, so recover the run id and
-           resolve it through the same ``complete_job`` path ``execute_complete``
-           uses. The task log then names the actual platform error (e.g. the
-           Glue ``ErrorMessage`` and log tail) with the run id, where the
-           default handling would report only a generic "trigger failure" with
-           ``run: <unknown>``.
+           triggers (notably AWS Glue) raise on FAILED/STOPPED/TIMEOUT, so a
+           finished-but-failed run reaches ``__fail__`` too. This recovers the
+           run id and resolves it through the same ``complete_job`` path
+           ``execute_complete`` uses, so the task log names the real platform
+           error instead of a generic "trigger failure" with ``run: <unknown>``.
 
-        2. A genuine Triggerer crash mid-poll (network drop, expired auth,
-           Triggerer restart), which carries no resolvable run. The default
-           ``resume_execution`` would raise a bare ``TaskDeferralError`` whose
-           root cause is buried in the Triggerer logs, so the error goes
-           through the per-platform ``describe_failure`` seam tagged
-           ``is_trigger_failure`` (bucketed ``trigger/polling``) and raises the
-           non-retryable ``AirflowFailException``. A crash mid-poll does not
-           mean the job is safe to resubmit.
+        2. A genuine Triggerer crash mid-poll, which carries no resolvable
+           run. This goes through the per-platform ``describe_failure`` seam
+           tagged ``is_trigger_failure`` and raises the non-retryable
+           ``AirflowFailException``, since a crash mid-poll doesn't mean the
+           job is safe to resubmit.
 
-        Every other resume (a normal trigger event) is delegated untouched to
-        the base implementation, which dispatches to ``execute_complete``.
+        Every other resume is delegated to the base implementation.
         """
         if next_method == "__fail__":
             next_kwargs = next_kwargs or {}
@@ -233,7 +222,9 @@ class SparkAgnosticExecuteOperator(BaseOperator):
             full = rehydrate(self.setup_info)
             handler = get_platform_handler(full["spark_family"], full)
 
-            error_text = "\n".join(traceback) if traceback else str(error)
+            # error and traceback can carry the run id independently of each
+            # other depending on the trigger, so check both.
+            error_text = "\n".join([*(traceback or []), str(error)])
             run_id = _terminal_run_id(error_text)
             if run_id is not None:
                 try:
@@ -241,16 +232,13 @@ class SparkAgnosticExecuteOperator(BaseOperator):
                         {"run_id": run_id}, context, cluster_info=self.cluster_info
                     )
                 except (AirflowException, AirflowFailException):
-                    # complete_job resolved the run and raised the classified,
-                    # de-noised failure naming the real platform error. Surface it.
+                    # This is already the classified failure from complete_job, so it propagates unchanged.
                     raise
                 except Exception as resolve_exc:  # noqa: BLE001
-                    # Couldn't resolve the run (API error, unexpected shape);
-                    # fall through to the generic trigger-failure classification.
+                    # The run couldn't be resolved, so this falls through to the generic classification.
                     self.log.warning("Could not resolve terminal run %s: %s", run_id, resolve_exc)
                 else:
-                    # The run actually succeeded despite the __fail__ (rare);
-                    # finalize it as a normal completion.
+                    # The run succeeded despite __fail__ (rare), so this finalizes normally.
                     return self._finalize(context, result)
 
             info = handler.describe_failure(

--- a/src/overture_airflow_provider/_operator.py
+++ b/src/overture_airflow_provider/_operator.py
@@ -231,9 +231,14 @@ class SparkAgnosticExecuteOperator(BaseOperator):
                     result = handler.complete_job(
                         {"run_id": run_id}, context, cluster_info=self.cluster_info
                     )
-                except (AirflowException, AirflowFailException):
-                    # This is already the classified failure from complete_job, so it propagates unchanged.
+                except AirflowFailException:
+                    # Already the classified, non-retryable failure; propagate unchanged.
                     raise
+                except AirflowException as resolve_exc:
+                    # complete_job only ever raises plain AirflowException, but a
+                    # resolved run_id means the job launched -- never retryable,
+                    # same as the launched-and-failed case in execute() above.
+                    raise AirflowFailException(str(resolve_exc)) from None
                 except Exception as resolve_exc:  # noqa: BLE001
                     # The run couldn't be resolved, so this falls through to the generic classification.
                     self.log.warning("Could not resolve terminal run %s: %s", run_id, resolve_exc)

--- a/src/overture_airflow_provider/_operator.py
+++ b/src/overture_airflow_provider/_operator.py
@@ -22,6 +22,7 @@ worker for hours.
 
 import datetime
 import json
+import re
 
 from overture_airflow_provider._airflow_compat import (
     AirflowException,
@@ -37,6 +38,25 @@ from overture_airflow_provider.links import (
 )
 from overture_airflow_provider.setup_info import rehydrate
 from overture_airflow_provider.spark_platform_handlers import get_platform_handler
+
+_GLUE_RUN_ID_RE = re.compile(r"\bjr_[0-9a-f]{16,}\b")
+
+
+def _terminal_run_id(error_text: str) -> str | None:
+    """Recover a Glue run id from a trigger error that reports a terminal state.
+
+    The AWS Glue trigger raises ``... Job jr_<hex> Run State: FAILED`` (or
+    STOPPED/TIMEOUT) on a terminal state, so a finished-but-failed run reaches
+    ``resume_execution`` through the ``__fail__`` sentinel. A message that both
+    names a run and reports a run state is a resolvable terminal failure; a
+    genuine Triggerer crash (a connection drop mid-poll) carries neither, so it
+    returns ``None`` and the caller keeps the generic trigger-failure
+    classification.
+    """
+    if "Run State" not in error_text:
+        return None
+    match = _GLUE_RUN_ID_RE.search(error_text)
+    return match.group(0) if match else None
 
 
 def _xcom_datetime_default(obj):
@@ -178,23 +198,31 @@ class SparkAgnosticExecuteOperator(BaseOperator):
     def resume_execution(self, next_method, next_kwargs, context):
         """Enrich deferral/trigger (Triggerer) failures before they surface.
 
-        When a provider trigger crashes mid-poll (network drop, expired auth,
-        Triggerer restart), Airflow resumes the task with the ``__fail__``
-        sentinel for ``next_method`` instead of the normal completion callback.
-        The default ``resume_execution`` would raise a bare ``TaskDeferralError``
-        whose root cause is buried in the Triggerer logs -- exactly the
-        unclassified noise this provider exists to tame.
+        Airflow resumes a deferred task with the ``__fail__`` sentinel for
+        ``next_method`` in two distinct situations, and this method separates
+        them:
 
-        We intercept that sentinel (the documented mechanism on both Airflow 2
-        and 3) and route the error through the same per-platform
-        ``describe_failure`` seam used by the submit and complete paths, tagged
-        ``is_trigger_failure`` so the classifier buckets it as ``trigger/polling``.
-        A trigger only exists once a job has launched, so this path is always
-        ``run_launched=True`` and raises the non-retryable
-        ``AirflowFailException`` -- a Triggerer crash mid-poll doesn't mean the
-        job is safe to resubmit. Every other resume (a normal trigger event) is
-        delegated untouched to the base implementation, which dispatches to
-        ``execute_complete``.
+        1. A finished job that reached a terminal non-success state. Some
+           provider triggers (notably AWS Glue) *raise* on a terminal FAILED /
+           STOPPED / TIMEOUT state, and a raising trigger reaches ``__fail__``.
+           That is a real, finished job failure, so recover the run id and
+           resolve it through the same ``complete_job`` path ``execute_complete``
+           uses. The task log then names the actual platform error (e.g. the
+           Glue ``ErrorMessage`` and log tail) with the run id, where the
+           default handling would report only a generic "trigger failure" with
+           ``run: <unknown>``.
+
+        2. A genuine Triggerer crash mid-poll (network drop, expired auth,
+           Triggerer restart), which carries no resolvable run. The default
+           ``resume_execution`` would raise a bare ``TaskDeferralError`` whose
+           root cause is buried in the Triggerer logs, so the error goes
+           through the per-platform ``describe_failure`` seam tagged
+           ``is_trigger_failure`` (bucketed ``trigger/polling``) and raises the
+           non-retryable ``AirflowFailException``. A crash mid-poll does not
+           mean the job is safe to resubmit.
+
+        Every other resume (a normal trigger event) is delegated untouched to
+        the base implementation, which dispatches to ``execute_complete``.
         """
         if next_method == "__fail__":
             next_kwargs = next_kwargs or {}
@@ -204,6 +232,27 @@ class SparkAgnosticExecuteOperator(BaseOperator):
             error = next_kwargs.get("error", "Trigger failed")
             full = rehydrate(self.setup_info)
             handler = get_platform_handler(full["spark_family"], full)
+
+            error_text = "\n".join(traceback) if traceback else str(error)
+            run_id = _terminal_run_id(error_text)
+            if run_id is not None:
+                try:
+                    result = handler.complete_job(
+                        {"run_id": run_id}, context, cluster_info=self.cluster_info
+                    )
+                except (AirflowException, AirflowFailException):
+                    # complete_job resolved the run and raised the classified,
+                    # de-noised failure naming the real platform error. Surface it.
+                    raise
+                except Exception as resolve_exc:  # noqa: BLE001
+                    # Couldn't resolve the run (API error, unexpected shape);
+                    # fall through to the generic trigger-failure classification.
+                    self.log.warning("Could not resolve terminal run %s: %s", run_id, resolve_exc)
+                else:
+                    # The run actually succeeded despite the __fail__ (rare);
+                    # finalize it as a normal completion.
+                    return self._finalize(context, result)
+
             info = handler.describe_failure(
                 error=error if isinstance(error, BaseException) else Exception(str(error)),
                 run_launched=True,

--- a/src/overture_airflow_provider/_setup.py
+++ b/src/overture_airflow_provider/_setup.py
@@ -130,6 +130,7 @@ def setup_spark_job(
         "databricks_gpu": databricks_config.gpu,
         "glue_execution_class": glue_config.execution_class,
         "glue_verbose": glue_config.verbose,
+        "glue_output_log_group": glue_config.output_log_group,
         "iam_role_name": glue_config.iam_role_name,
         # Registry params stored for client reconstruction after XCom round-trip
         "codeartifact_domain_owner": package_registry.domain_owner,

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -280,11 +280,16 @@ class GlueConfig:
             task log. Set ``False`` to silence that stream (e.g. for very chatty
             jobs) and rely on the Glue console / classified failure message
             instead.
+        output_log_group: CloudWatch log group holding each run's driver
+            stdout, keyed by run id. Defaults to Glue's own
+            ``/aws-glue/jobs/output``; override only if your jobs are
+            configured to write continuous logging output elsewhere.
     """
 
     iam_role_name: str = "AWSGlueServiceRole"
     execution_class: str = "STANDARD"
     verbose: bool = True
+    output_log_group: str = "/aws-glue/jobs/output"
 
 
 @dataclass

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -212,6 +212,7 @@ def _build_render_setup_info(
         "databricks_gpu": databricks_config.gpu,
         "glue_execution_class": glue_config.execution_class,
         "glue_verbose": glue_config.verbose,
+        "glue_output_log_group": glue_config.output_log_group,
         "iam_role_name": glue_config.iam_role_name,
         "codeartifact_domain_owner": package_registry.domain_owner,
         "codeartifact_domain": package_registry.domain,

--- a/src/overture_airflow_provider/setup_info.py
+++ b/src/overture_airflow_provider/setup_info.py
@@ -56,6 +56,7 @@ SERIALIZABLE_KEYS = (
     "databricks_gpu",
     "glue_execution_class",
     "glue_verbose",
+    "glue_output_log_group",
     "iam_role_name",
     "codeartifact_domain_owner",
     "codeartifact_domain",

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -644,6 +644,38 @@ class TestCompleteGlueJob:
         assert call_kwargs["logGroupName"] == "/aws-glue/jobs/output"
         assert call_kwargs["logStreamName"] == "jr_abc123"
 
+    def test_uses_configured_log_group_override(self):
+        """A consumer's GlueConfig.output_log_group flows through setup_info
+        to the CloudWatch fetch, for jobs that write continuous logging
+        output to a group other than Glue's own default."""
+        from overture_airflow_provider._glue import complete_glue_job
+
+        setup_info = {
+            **_glue_setup_info(),
+            "glue_output_log_group": "/custom/glue-output",
+        }
+        handler = GluePlatformHandler(setup_info)
+        context = {"ti": MagicMock(task_id="execute_spark_job")}
+
+        mock_glue = MagicMock()
+        mock_glue.get_job_run.return_value = {
+            "JobRun": {"JobRunState": "FAILED", "ErrorMessage": "boom"}
+        }
+        mock_logs = MagicMock()
+        mock_logs.get_log_events.return_value = {
+            "events": [{"message": "Running autoDebugger shutdown hook.", "timestamp": 0}]
+        }
+
+        def _client(service_name, **kwargs):
+            return {"glue": mock_glue, "logs": mock_logs}[service_name]
+
+        with patch("overture_airflow_provider._glue.boto3.client", side_effect=_client):
+            with pytest.raises(AirflowException):
+                complete_glue_job(setup_info, "jr_abc123", context, handler=handler)
+
+        call_kwargs = mock_logs.get_log_events.call_args.kwargs
+        assert call_kwargs["logGroupName"] == "/custom/glue-output"
+
     def test_output_log_fetch_failure_still_renders_message(self):
         """A CloudWatch fetch failure (missing stream, throttling, permissions)
         never breaks failure reporting, so the message just has no cause line."""

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -592,6 +592,79 @@ class TestCompleteGlueJob:
         assert "AccessDenied" in msg
         assert "hint:" in msg
 
+    def _run_with_logs_client(self, job_run: dict, log_events: list[dict] | None):
+        """Run complete_glue_job with distinct mocks per boto3 client service.
+
+        The other tests in this class patch boto3.client to a single mock
+        for every service, which is fine when nothing calls "logs". These
+        tests exercise the CloudWatch fallback, so glue and logs need their
+        own mocks with their own return values.
+        """
+        from overture_airflow_provider._glue import complete_glue_job
+
+        handler = GluePlatformHandler(_glue_setup_info())
+        context = {"ti": MagicMock(task_id="execute_spark_job")}
+
+        mock_glue = MagicMock()
+        mock_glue.get_job_run.return_value = {"JobRun": job_run}
+        mock_logs = MagicMock()
+        if log_events is None:
+            mock_logs.get_log_events.side_effect = RuntimeError("stream not found")
+        else:
+            mock_logs.get_log_events.return_value = {"events": log_events}
+
+        def _client(service_name, **kwargs):
+            return {"glue": mock_glue, "logs": mock_logs}[service_name]
+
+        with patch("overture_airflow_provider._glue.boto3.client", side_effect=_client):
+            with pytest.raises(AirflowException) as exc:
+                complete_glue_job(_glue_setup_info(), "jr_abc123", context, handler=handler)
+        return str(exc.value), mock_logs
+
+    def test_fetches_output_log_tail_when_log_tail_empty(self):
+        """When Glue's own LogTail is empty, the run's CloudWatch output log
+        supplies the root cause, e.g. a validation job's full error report."""
+        msg, mock_logs = self._run_with_logs_client(
+            job_run={
+                "JobRunState": "FAILED",
+                "ErrorMessage": "ValueError: Schema mismatch for buildings/building_part:",
+            },
+            log_events=[
+                {"message": "Schema mismatch for buildings/building_part:"},
+                {"message": "  sources[].provider: expected StringType, got missing"},
+            ],
+        )
+        assert "sources[].provider: expected StringType, got missing" in msg
+        mock_logs.get_log_events.assert_called_once()
+        call_kwargs = mock_logs.get_log_events.call_args.kwargs
+        assert call_kwargs["logGroupName"] == "/aws-glue/jobs/output"
+        assert call_kwargs["logStreamName"] == "jr_abc123"
+
+    def test_output_log_fetch_failure_still_renders_message(self):
+        """A CloudWatch fetch failure (missing stream, throttling, permissions)
+        never breaks failure reporting; the message just has no cause line."""
+        msg, _ = self._run_with_logs_client(
+            job_run={"JobRunState": "FAILED", "ErrorMessage": "boom"},
+            log_events=None,
+        )
+        assert "Spark job FAILED on GLUE" in msg
+        assert "cause:" not in msg
+
+    def test_prefers_glue_log_tail_when_present(self):
+        """Glue's own LogTail, on the rare run where it is populated, is used
+        as-is; the CloudWatch output log is never queried."""
+        msg, mock_logs = self._run_with_logs_client(
+            job_run={
+                "JobRunState": "FAILED",
+                "ErrorMessage": "boom",
+                "LogTail": "some stderr tail from Glue itself",
+            },
+            log_events=[{"message": "should not appear"}],
+        )
+        assert "some stderr tail from Glue itself" in msg
+        assert "should not appear" not in msg
+        mock_logs.get_log_events.assert_not_called()
+
 
 class TestGlueHandlerCompleteJobEventContract:
     """GlueJobCompleteTrigger emits the run id under "value" (AwsBaseWaiterTrigger

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -580,6 +580,11 @@ class TestCompleteGlueJob:
                 "ErrorMessage": "S3 AccessDenied on DeleteObject",
             }
         }
+        # This mock also stands in for the "logs" client, so it needs the
+        # shutdown marker or the poll loop waits in real time for one.
+        mock_glue.get_log_events.return_value = {
+            "events": [{"message": "Running autoDebugger shutdown hook.", "timestamp": 0}]
+        }
         with patch(
             "overture_airflow_provider._glue.boto3.client",
             return_value=mock_glue,
@@ -593,13 +598,8 @@ class TestCompleteGlueJob:
         assert "hint:" in msg
 
     def _run_with_logs_client(self, job_run: dict, log_events: list[dict] | None):
-        """Run complete_glue_job with distinct mocks per boto3 client service.
-
-        The other tests in this class patch boto3.client to a single mock
-        for every service, which is fine when nothing calls "logs". These
-        tests exercise the CloudWatch fallback, so glue and logs need their
-        own mocks with their own return values.
-        """
+        """Run complete_glue_job with distinct "glue" and "logs" client mocks,
+        needed here since these tests exercise the CloudWatch fallback."""
         from overture_airflow_provider._glue import complete_glue_job
 
         handler = GluePlatformHandler(_glue_setup_info())
@@ -630,8 +630,12 @@ class TestCompleteGlueJob:
                 "ErrorMessage": "ValueError: Schema mismatch for buildings/building_part:",
             },
             log_events=[
-                {"message": "Schema mismatch for buildings/building_part:"},
-                {"message": "  sources[].provider: expected StringType, got missing"},
+                {"message": "Schema mismatch for buildings/building_part:", "timestamp": 0},
+                {
+                    "message": "  sources[].provider: expected StringType, got missing",
+                    "timestamp": 1,
+                },
+                {"message": "Running autoDebugger shutdown hook.", "timestamp": 2},
             ],
         )
         assert "sources[].provider: expected StringType, got missing" in msg
@@ -642,7 +646,7 @@ class TestCompleteGlueJob:
 
     def test_output_log_fetch_failure_still_renders_message(self):
         """A CloudWatch fetch failure (missing stream, throttling, permissions)
-        never breaks failure reporting; the message just has no cause line."""
+        never breaks failure reporting, so the message just has no cause line."""
         msg, _ = self._run_with_logs_client(
             job_run={"JobRunState": "FAILED", "ErrorMessage": "boom"},
             log_events=None,
@@ -652,7 +656,7 @@ class TestCompleteGlueJob:
 
     def test_prefers_glue_log_tail_when_present(self):
         """Glue's own LogTail, on the rare run where it is populated, is used
-        as-is; the CloudWatch output log is never queried."""
+        as-is, so the CloudWatch output log is never queried."""
         msg, mock_logs = self._run_with_logs_client(
             job_run={
                 "JobRunState": "FAILED",
@@ -664,6 +668,119 @@ class TestCompleteGlueJob:
         assert "some stderr tail from Glue itself" in msg
         assert "should not appear" not in msg
         mock_logs.get_log_events.assert_not_called()
+
+    def test_polls_until_shutdown_marker_appears(self):
+        """A first fetch that lands before Glue's own shutdown line has been
+        delivered to CloudWatch is discarded once a later fetch catches it."""
+        from overture_airflow_provider._glue import _fetch_glue_output_log_tail
+
+        early = {"events": [{"message": "Installed packages", "timestamp": 0}]}
+        caught_up = {
+            "events": [
+                {"message": "Schema mismatch for buildings/building", "timestamp": 1},
+                {"message": "Running autoDebugger shutdown hook.", "timestamp": 2},
+            ]
+        }
+        mock_logs = MagicMock()
+        mock_logs.get_log_events.side_effect = [early, caught_up]
+        mock_sleep = MagicMock()
+
+        with patch("overture_airflow_provider._glue.boto3.client", return_value=mock_logs):
+            result = _fetch_glue_output_log_tail(
+                "us-west-2", "jr_abc123", poll=True, sleep=mock_sleep
+            )
+
+        assert result == (
+            "Schema mismatch for buildings/building\nRunning autoDebugger shutdown hook."
+        )
+        assert mock_logs.get_log_events.call_count == 2
+        mock_sleep.assert_called_once()
+
+    def test_stops_polling_after_max_attempts(self):
+        """A log that never shows the shutdown line still returns the best
+        tail seen once the poll attempts run out."""
+        from overture_airflow_provider._glue import (
+            _LOG_TAIL_POLL_ATTEMPTS,
+            _fetch_glue_output_log_tail,
+        )
+
+        stale = {"events": [{"message": "still bootstrapping", "timestamp": 0}]}
+        mock_logs = MagicMock()
+        mock_logs.get_log_events.return_value = stale
+        mock_sleep = MagicMock()
+
+        with patch("overture_airflow_provider._glue.boto3.client", return_value=mock_logs):
+            result = _fetch_glue_output_log_tail(
+                "us-west-2", "jr_abc123", poll=True, sleep=mock_sleep
+            )
+
+        assert result == "still bootstrapping"
+        assert mock_logs.get_log_events.call_count == _LOG_TAIL_POLL_ATTEMPTS
+        assert mock_sleep.call_count == _LOG_TAIL_POLL_ATTEMPTS - 1
+
+    def test_no_poll_by_default_is_a_single_fetch(self):
+        """poll=False (the default) makes exactly one fetch, matching the
+        original one-shot behavior for callers that don't opt into polling."""
+        from overture_airflow_provider._glue import _fetch_glue_output_log_tail
+
+        mock_logs = MagicMock()
+        mock_logs.get_log_events.return_value = {
+            "events": [{"message": "Installed packages", "timestamp": 0}]
+        }
+        mock_sleep = MagicMock()
+
+        with patch("overture_airflow_provider._glue.boto3.client", return_value=mock_logs):
+            result = _fetch_glue_output_log_tail("us-west-2", "jr_abc123", sleep=mock_sleep)
+
+        assert result == "Installed packages"
+        mock_logs.get_log_events.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_tolerates_events_missing_expected_keys(self):
+        """A malformed CloudWatch event (missing timestamp or message) can't
+        break the "returns None on any failure" contract with a KeyError."""
+        from overture_airflow_provider._glue import _fetch_glue_output_log_tail
+
+        malformed = {
+            "events": [
+                {"message": "Running autoDebugger shutdown hook.", "timestamp": 1},
+                {"timestamp": 2},
+                {"message": "no timestamp here"},
+            ]
+        }
+        mock_logs = MagicMock()
+        mock_logs.get_log_events.return_value = malformed
+
+        with patch("overture_airflow_provider._glue.boto3.client", return_value=mock_logs):
+            result = _fetch_glue_output_log_tail("us-west-2", "jr_abc123")
+
+        assert result is not None
+        assert "Running autoDebugger shutdown hook." in result
+
+    def test_sorts_events_by_timestamp_before_joining(self):
+        """The API can return complete events out of their own timestamp
+        order, so sorting before joining keeps bounded_tail's truncation
+        landing on the real end of the log."""
+        from overture_airflow_provider._glue import _fetch_glue_output_log_tail
+
+        out_of_order = {
+            "events": [
+                {"message": "Running autoDebugger shutdown hook.", "timestamp": 300},
+                {"message": "Installed packages: ...", "timestamp": 100},
+                {"message": "Schema mismatch for buildings/building", "timestamp": 200},
+            ]
+        }
+        mock_logs = MagicMock()
+        mock_logs.get_log_events.return_value = out_of_order
+
+        with patch("overture_airflow_provider._glue.boto3.client", return_value=mock_logs):
+            result = _fetch_glue_output_log_tail("us-west-2", "jr_abc123", poll=True)
+
+        assert result == (
+            "Installed packages: ...\n"
+            "Schema mismatch for buildings/building\n"
+            "Running autoDebugger shutdown hook."
+        )
 
 
 class TestGlueHandlerCompleteJobEventContract:

--- a/tests/test_spark_agnostic_operator.py
+++ b/tests/test_spark_agnostic_operator.py
@@ -211,7 +211,10 @@ def test_resume_execution_resolves_terminal_glue_failure():
     """A trigger that raised on a terminal FAILED state resolves as a real job
     failure: the run id is recovered, complete_job surfaces the platform
     error, and the generic trigger-failure classification is skipped."""
-    from overture_airflow_provider._airflow_compat import AirflowException
+    from overture_airflow_provider._airflow_compat import (
+        AirflowException,
+        AirflowFailException,
+    )
 
     op = _make_operator()
     handler = MagicMock()
@@ -237,6 +240,10 @@ def test_resume_execution_resolves_terminal_glue_failure():
 
     msg = str(exc.value)
     assert "Validation failed: 9 errors" in msg
+    # The run id resolved above means the job launched: never retryable, same
+    # as the launched-and-failed case in execute(), even though complete_job
+    # itself only ever raises the plain (retryable-by-default) AirflowException.
+    assert type(exc.value) is AirflowFailException
     # Resolved via complete_job, so the generic bucket is skipped.
     handler.complete_job.assert_called_once()
     assert handler.complete_job.call_args.args[0] == {"run_id": run_id}

--- a/tests/test_spark_agnostic_operator.py
+++ b/tests/test_spark_agnostic_operator.py
@@ -207,6 +207,81 @@ def test_execute_complete_calls_handler_and_finalizes():
     assert result["spark_impl"] == "GLUE_SEDONA"
 
 
+def test_resume_execution_resolves_terminal_glue_failure():
+    """A trigger that raised on a terminal FAILED state is resolved as a real
+    job failure: the run id is recovered and complete_job surfaces the platform
+    error, so the task log names the real cause and skips the generic
+    trigger-failure classification."""
+    from overture_airflow_provider._airflow_compat import AirflowException
+
+    op = _make_operator()
+    handler = MagicMock()
+    # complete_glue_job raises the classified, de-noised failure naming the
+    # real Glue ErrorMessage; simulate that here.
+    handler.complete_job.side_effect = AirflowException(
+        "Spark job FAILED on GLUE\n  reason: Validation failed: 9 errors in divisions/division"
+    )
+
+    run_id = "jr_" + "a" * 64
+    with (
+        patch("overture_airflow_provider._operator.rehydrate", return_value=_FULL),
+        patch(
+            "overture_airflow_provider._operator.get_platform_handler",
+            return_value=handler,
+        ),
+    ):
+        with pytest.raises(AirflowException) as exc:
+            op.resume_execution(
+                "__fail__",
+                {"error": f"Exiting Job {run_id} Run State: FAILED"},
+                {"ti": MagicMock()},
+            )
+
+    msg = str(exc.value)
+    assert "Validation failed: 9 errors" in msg
+    # Resolved through the completion path; the generic trigger bucket is skipped.
+    handler.complete_job.assert_called_once()
+    assert handler.complete_job.call_args.args[0] == {"run_id": run_id}
+    handler.describe_failure.assert_not_called()
+
+
+def test_resume_execution_falls_back_when_run_unresolvable():
+    """If the recovered run can't be resolved (API error), the generic
+    trigger-failure classification still surfaces and the raw resolution error
+    stays contained."""
+    from overture_airflow_provider._airflow_compat import AirflowFailException
+    from overture_airflow_provider._failures import TRIGGER_POLLING, FailureInfo
+
+    op = _make_operator()
+    handler = MagicMock()
+    handler.complete_job.side_effect = RuntimeError("get_job_run timed out")
+    handler.describe_failure.return_value = FailureInfo(
+        platform="GLUE",
+        job_ref="metrics_job",
+        state="FAILED",
+        reason="unresolved",
+        classification=TRIGGER_POLLING,
+    )
+
+    run_id = "jr_" + "b" * 64
+    with (
+        patch("overture_airflow_provider._operator.rehydrate", return_value=_FULL),
+        patch(
+            "overture_airflow_provider._operator.get_platform_handler",
+            return_value=handler,
+        ),
+    ):
+        with pytest.raises(AirflowFailException) as exc:
+            op.resume_execution(
+                "__fail__",
+                {"error": f"Exiting Job {run_id} Run State: FAILED"},
+                {"ti": MagicMock()},
+            )
+
+    assert "trigger/polling failure" in str(exc.value)
+    handler.describe_failure.assert_called_once()
+
+
 def test_resume_execution_delegates_normal_event():
     op = _make_operator()
     op.execute_complete = MagicMock(return_value="finalized")

--- a/tests/test_spark_agnostic_operator.py
+++ b/tests/test_spark_agnostic_operator.py
@@ -208,16 +208,14 @@ def test_execute_complete_calls_handler_and_finalizes():
 
 
 def test_resume_execution_resolves_terminal_glue_failure():
-    """A trigger that raised on a terminal FAILED state is resolved as a real
-    job failure: the run id is recovered and complete_job surfaces the platform
-    error, so the task log names the real cause and skips the generic
-    trigger-failure classification."""
+    """A trigger that raised on a terminal FAILED state resolves as a real job
+    failure: the run id is recovered, complete_job surfaces the platform
+    error, and the generic trigger-failure classification is skipped."""
     from overture_airflow_provider._airflow_compat import AirflowException
 
     op = _make_operator()
     handler = MagicMock()
-    # complete_glue_job raises the classified, de-noised failure naming the
-    # real Glue ErrorMessage; simulate that here.
+    # Mirrors complete_glue_job's classified failure format.
     handler.complete_job.side_effect = AirflowException(
         "Spark job FAILED on GLUE\n  reason: Validation failed: 9 errors in divisions/division"
     )
@@ -239,10 +237,41 @@ def test_resume_execution_resolves_terminal_glue_failure():
 
     msg = str(exc.value)
     assert "Validation failed: 9 errors" in msg
-    # Resolved through the completion path; the generic trigger bucket is skipped.
+    # Resolved via complete_job, so the generic bucket is skipped.
     handler.complete_job.assert_called_once()
     assert handler.complete_job.call_args.args[0] == {"run_id": run_id}
     handler.describe_failure.assert_not_called()
+
+
+def test_resume_execution_finds_run_id_in_error_when_traceback_lacks_it():
+    """The run id can live only in `error` even when a traceback is present,
+    e.g. if the trigger's own frames don't repeat the final exception line."""
+    from overture_airflow_provider._airflow_compat import AirflowException
+
+    op = _make_operator()
+    handler = MagicMock()
+    handler.complete_job.side_effect = AirflowException("Spark job FAILED on GLUE")
+
+    run_id = "jr_" + "c" * 64
+    with (
+        patch("overture_airflow_provider._operator.rehydrate", return_value=_FULL),
+        patch(
+            "overture_airflow_provider._operator.get_platform_handler",
+            return_value=handler,
+        ),
+    ):
+        with pytest.raises(AirflowException):
+            op.resume_execution(
+                "__fail__",
+                {
+                    "error": f"Exiting Job {run_id} Run State: FAILED",
+                    "traceback": ["Traceback (most recent call last):", '  File "x.py", line 1'],
+                },
+                {"ti": MagicMock()},
+            )
+
+    handler.complete_job.assert_called_once()
+    assert handler.complete_job.call_args.args[0] == {"run_id": run_id}
 
 
 def test_resume_execution_falls_back_when_run_unresolvable():


### PR DESCRIPTION
Closes #73 

This digs into CloudWatch logs so that even if a job fails, *all* of its output logs make it into Airflow's logs (useful for debugging, surfacing validation failures, etc.)

I tested this in my local Airflow and it was able to print schema/data validation failures to the Airflow logs!
