### PR TITLE
[FEATURE] Serve native Python wheels to Glue from S3 cache with PyPI fallback

### DIFF
--- a/src/overture_airflow_provider/_glue.py
+++ b/src/overture_airflow_provider/_glue.py
@@ -76,6 +76,9 @@ def download_python_packages_glue(
             packages=packages_to_download,
             python_version=setup_info["python_version"],
             job_runner_wheel_prefix=None,  # runners are now bundled in the provider
+            # Serve native wheels (e.g. apache-sedona) from the S3 cache so Glue
+            # bootstrap doesn't depend on public PyPI availability.
+            cache_native_wheels=True,
         )
     )
 
@@ -219,11 +222,17 @@ def build_glue_operator_kwargs(
 
     native_packages = package_info.get("native_packages", [])
     sedona_module = jar_info.get("sedona_module")
-    additional_modules = [sedona_module] if sedona_module else []
-    if native_packages:
-        for pkg in native_packages:
-            if "apache-sedona" not in pkg:
-                additional_modules.append(pkg)
+
+    # Entries may be pip specs ("apache-sedona==1.7.2") or S3 wheel URIs
+    # (".../apache_sedona-1.7.2-...whl"); normalize underscores so sedona is
+    # detected — and listed — exactly once, preferring the S3 wheel from the
+    # package step over the bare PyPI spec in jar_info.
+    def _is_sedona(entry: str) -> bool:
+        return "apache-sedona" in entry.replace("_", "-").lower()
+
+    sedona_entries = [pkg for pkg in native_packages if _is_sedona(pkg)]
+    additional_modules = sedona_entries or ([sedona_module] if sedona_module else [])
+    additional_modules += [pkg for pkg in native_packages if not _is_sedona(pkg)]
 
     glue_job_default_args = {
         "--extra-jars": jar_info["jars_s3"],

--- a/src/overture_airflow_provider/spark_agnostic_helpers.py
+++ b/src/overture_airflow_provider/spark_agnostic_helpers.py
@@ -23,6 +23,9 @@ from overture_airflow_provider.python_package_utils import (
 class SparkAgnosticHelper:
     """Shared logic for Spark-agnostic operations (package + JAR caching)."""
 
+    # Shared S3 cache location for Python wheels from the private registry.
+    S3_PYPI_CACHE_PREFIX = "python_wheels/codeartifact_cache"
+
     def __init__(
         self,
         job_name: str,
@@ -98,28 +101,72 @@ class SparkAgnosticHelper:
                 return True
         return False
 
+    def _cache_native_wheel(self, wheel_path: str, wheel_filename: str) -> str | None:
+        """Cache a native wheel in the shared S3 wheel cache.
+
+        Returns the ``s3://`` URI on success, or ``None`` when the cache
+        check/upload fails (caller falls back to a pip spec).
+        """
+        cached_s3_key = f"{self.S3_PYPI_CACHE_PREFIX}/{wheel_filename}"
+        cached_s3_path = f"s3://{self.s3_bucket}/{cached_s3_key}"
+        try:
+            try:
+                self.s3_client.head_object(Bucket=self.s3_bucket, Key=cached_s3_key)
+                print(f"Found cached native wheel in S3: {cached_s3_path}")
+                return cached_s3_path
+            except self.s3_client.exceptions.ClientError as exc:
+                if exc.response["Error"]["Code"] != "404":
+                    raise
+            self.s3_client.upload_file(wheel_path, self.s3_bucket, cached_s3_key)
+            print(f"Uploaded native wheel to shared cache: {cached_s3_path}")
+            return cached_s3_path
+        except Exception as exc:
+            print(
+                f"WARNING: failed to cache native wheel {wheel_filename} in S3 ({exc}); "
+                f"falling back to pip install from PyPI at cluster bootstrap"
+            )
+            return None
+
     def download_and_cache_python_packages(
         self,
         py_pi_client,
         packages: list[str],
         python_version: str,
         job_runner_wheel_prefix: str | None = None,
+        cache_native_wheels: bool = False,
     ) -> tuple[str, str | None, str, list[str]]:
         """Download Python packages and cache them in S3.
 
-        Native deps are detected from wheel filenames and excluded from S3
-        uploads. Only **explicitly requested** packages (in ``packages``) are
-        tracked and returned for install via ``--additional-python-modules``
-        on Glue. Transitive native deps that exist in the target environment
-        (e.g. numpy/shapely) are not included.
+        Native deps are detected from wheel filenames and excluded from the
+        ``--extra-py-files`` S3 uploads. Only **explicitly requested**
+        packages (in ``packages``) are tracked and returned for install via
+        ``--additional-python-modules`` on Glue. Transitive native deps that
+        exist in the target environment (e.g. numpy/shapely) are not included.
+
+        When ``cache_native_wheels`` is True, explicitly requested native
+        wheels are uploaded to the shared S3 wheel cache and returned as
+        ``s3://.../*.whl`` URIs (Glue installs those without touching public
+        PyPI). If caching a wheel fails, that package falls back to a bare
+        ``pkg==version`` spec (pip-installed from PyPI at cluster bootstrap).
+
+        Args:
+            py_pi_client: CodeArtifact/PyPI client for authenticated downloads.
+            packages: Explicitly requested package specs.
+            python_version: Target Python version for wheel resolution.
+            job_runner_wheel_prefix: Wheel filename prefix to keep locally.
+            cache_native_wheels: Upload explicitly requested native wheels to
+                the shared S3 cache and return their S3 URIs instead of pip
+                specs. Leave False for platforms that require pip specs
+                (e.g. Wherobots).
 
         Returns:
             Tuple of:
               - comma-separated S3 paths of cached pure-Python wheels,
               - job-runner wheel local path (or None),
               - temp folder path (caller cleans up),
-              - list of explicitly requested native package specs
-                (e.g. ``['numba==0.59.0']``).
+              - list of explicitly requested native package entries: pip
+                specs (e.g. ``'numba==0.59.0'``) or, with
+                ``cache_native_wheels``, S3 wheel URIs.
         """
         # Force-install via pip for caller-configured complex packages.
         excluded_native_packages = [pkg for pkg in packages if self._force_pip_install(pkg)]
@@ -148,11 +195,12 @@ class SparkAgnosticHelper:
         py_pi_downloader.download_packages(packages, python_version=python_version)
 
         # Shared S3 cache location for Python wheels from the private registry.
-        s3_pypi_cache_prefix = "python_wheels/codeartifact_cache"
+        s3_pypi_cache_prefix = self.S3_PYPI_CACHE_PREFIX
 
         cached_wheels: list[str] = []
         wheels_to_upload: list[str] = []
         job_runner_whl: str | None = None
+        handled_native_names: set[str] = set()
 
         for file in os.listdir(tmp_folder_pypi):
             if not file.endswith(".whl"):
@@ -167,12 +215,18 @@ class SparkAgnosticHelper:
                 pkg_name, version = self._parse_wheel_filename(file)
                 if pkg_name:
                     if pkg_name.lower() in requested_package_names:
-                        if pkg_name not in excluded_native_packages:
-                            excluded_native_packages.append(f"{pkg_name}=={version}")
-                            print(
-                                f"Native package (explicitly requested): {file} -> "
-                                f"will install via pip: {pkg_name}=={version}"
-                            )
+                        if pkg_name.lower() not in handled_native_names:
+                            handled_native_names.add(pkg_name.lower())
+                            entry = None
+                            if cache_native_wheels:
+                                entry = self._cache_native_wheel(wheel_path, file)
+                            if entry is None:
+                                entry = f"{pkg_name}=={version}"
+                                print(
+                                    f"Native package (explicitly requested): {file} -> "
+                                    f"will install via pip: {entry}"
+                                )
+                            excluded_native_packages.append(entry)
                     else:
                         print(f"Native package (transitive dep, skipping): {file}")
                 else:
@@ -210,7 +264,9 @@ class SparkAgnosticHelper:
         print(f"Using Python wheels from cache and uploads: {py_files}")
 
         if excluded_native_packages:
-            print(f"Native packages to install via pip: {excluded_native_packages}")
+            print(
+                f"Native package install entries (S3 wheel or pip spec): {excluded_native_packages}"
+            )
 
         return py_files, job_runner_whl, tmp_folder_pypi, excluded_native_packages
 

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -293,6 +293,7 @@ class TestGlueExecuteJob:
         iam_role_name="AWSGlueServiceRole",
         simulate_submit=False,
         mapping_context=False,
+        native_packages=None,
     ):
         from overture_airflow_provider._glue import submit_glue_job
 
@@ -303,7 +304,7 @@ class TestGlueExecuteJob:
             "scala_script_location": "s3://bucket/job_runner_glue.scala",
             "s3_bucket": "test-bucket",
             "s3_prefix": "overture-airflow-operator/test.Job/20240101",
-            "native_packages": [],
+            "native_packages": native_packages or [],
         }
         jar_info = {
             "jars_s3": "s3://bucket/sedona.jar,s3://bucket/geotools.jar",
@@ -387,6 +388,42 @@ class TestGlueExecuteJob:
         default_args = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"]
         assert "--additional-python-modules" in default_args
         assert "apache-sedona==1.7.0" in default_args["--additional-python-modules"]
+
+    def test_sedona_s3_wheel_preferred_over_pypi_spec(self):
+        sedona_uri = (
+            "s3://test-bucket/python_wheels/codeartifact_cache/"
+            "apache_sedona-1.7.0-cp311-cp311-manylinux_2_17_x86_64.whl"
+        )
+        _, captured = self._run_glue(native_packages=[sedona_uri])
+        modules = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"][
+            "--additional-python-modules"
+        ]
+        assert sedona_uri in modules
+        assert "apache-sedona==1.7.0" not in modules
+        # sedona listed exactly once
+        assert sum("sedona" in m for m in modules.split(", ")) == 1
+
+    def test_sedona_pip_spec_fallback_not_duplicated(self):
+        _, captured = self._run_glue(native_packages=["apache-sedona==1.7.0"])
+        modules = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"][
+            "--additional-python-modules"
+        ]
+        assert modules.split(", ").count("apache-sedona==1.7.0") == 1
+        assert sum("sedona" in m for m in modules.split(", ")) == 1
+
+    def test_mixed_native_packages_sedona_uri_and_pip_spec(self):
+        sedona_uri = (
+            "s3://test-bucket/python_wheels/codeartifact_cache/"
+            "apache_sedona-1.7.0-cp311-cp311-manylinux_2_17_x86_64.whl"
+        )
+        _, captured = self._run_glue(native_packages=[sedona_uri, "numba==0.59.0"])
+        modules = captured["call_kwargs"]["create_job_kwargs"]["DefaultArguments"][
+            "--additional-python-modules"
+        ]
+        parts = modules.split(", ")
+        assert sedona_uri in parts
+        assert "numba==0.59.0" in parts
+        assert sum("sedona" in m for m in parts) == 1
 
     def test_extra_jars_in_default_args(self):
         _, captured = self._run_glue()

--- a/tests/test_spark_agnostic_helpers.py
+++ b/tests/test_spark_agnostic_helpers.py
@@ -121,8 +121,10 @@ class TestDownloadAndCachePythonPackages:
         requested_packages,
         existing_s3_keys=None,
         job_runner_wheel_prefix=None,
+        cache_native_wheels=False,
+        s3_mock=None,
     ):
-        s3_mock = _make_s3_mock(existing_s3_keys)
+        s3_mock = s3_mock if s3_mock is not None else _make_s3_mock(existing_s3_keys)
         helper = _make_helper(s3_mock)
 
         mock_client = MagicMock()
@@ -149,6 +151,7 @@ class TestDownloadAndCachePythonPackages:
                 packages=list(requested_packages),
                 python_version="3.11",
                 job_runner_wheel_prefix=job_runner_wheel_prefix,
+                cache_native_wheels=cache_native_wheels,
             )
 
         result_with_meta = result + (s3_mock,)
@@ -238,6 +241,110 @@ class TestDownloadAndCachePythonPackages:
         )
         assert py_files == ""
         assert native == []
+        assert len(s3._uploaded) == 0
+
+
+SEDONA_WHEEL = "apache_sedona-1.7.2-cp311-cp311-manylinux_2_17_x86_64.whl"
+SEDONA_CACHE_KEY = f"python_wheels/codeartifact_cache/{SEDONA_WHEEL}"
+SEDONA_S3_URI = f"s3://test-glue-assets/{SEDONA_CACHE_KEY}"
+
+
+class TestCacheNativeWheels:
+    """cache_native_wheels=True: native wheels served from the S3 cache."""
+
+    _run = TestDownloadAndCachePythonPackages._run
+
+    def test_native_wheel_uploaded_on_cache_miss(self):
+        _, _, _, native, s3 = self._run(
+            wheel_files=[SEDONA_WHEEL],
+            requested_packages=["apache-sedona==1.7.2"],
+            cache_native_wheels=True,
+        )
+        assert native == [SEDONA_S3_URI]
+        assert (s3._uploaded[0][1]) == SEDONA_CACHE_KEY
+
+    def test_native_wheel_not_uploaded_on_cache_hit(self):
+        _, _, _, native, s3 = self._run(
+            wheel_files=[SEDONA_WHEEL],
+            requested_packages=["apache-sedona==1.7.2"],
+            existing_s3_keys={SEDONA_CACHE_KEY},
+            cache_native_wheels=True,
+        )
+        assert native == [SEDONA_S3_URI]
+        assert len(s3._uploaded) == 0
+
+    def test_native_wheel_not_in_extra_py_files(self):
+        py_files, _, _, _, _ = self._run(
+            wheel_files=[SEDONA_WHEEL],
+            requested_packages=["apache-sedona==1.7.2"],
+            cache_native_wheels=True,
+        )
+        assert SEDONA_WHEEL not in py_files
+
+    def test_upload_failure_falls_back_to_pip_spec(self):
+        s3_mock = _make_s3_mock()
+        s3_mock.upload_file.side_effect = RuntimeError("s3 unavailable")
+        _, _, _, native, _ = self._run(
+            wheel_files=[SEDONA_WHEEL],
+            requested_packages=["apache-sedona==1.7.2"],
+            cache_native_wheels=True,
+            s3_mock=s3_mock,
+        )
+        assert native == ["apache-sedona==1.7.2"]
+
+    def test_head_object_non_404_falls_back_to_pip_spec(self):
+        s3_mock = _make_s3_mock()
+        s3_mock.head_object.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadObject"
+        )
+        _, _, _, native, _ = self._run(
+            wheel_files=[SEDONA_WHEEL],
+            requested_packages=["apache-sedona==1.7.2"],
+            cache_native_wheels=True,
+            s3_mock=s3_mock,
+        )
+        assert native == ["apache-sedona==1.7.2"]
+
+    def test_transitive_native_dep_still_skipped(self):
+        _, _, _, native, s3 = self._run(
+            wheel_files=[
+                SEDONA_WHEEL,
+                "numpy-1.24.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+            ],
+            requested_packages=["apache-sedona==1.7.2"],
+            cache_native_wheels=True,
+        )
+        assert native == [SEDONA_S3_URI]
+        assert all("numpy" not in key for _, key in s3._uploaded)
+
+    def test_force_pip_package_stays_bare_spec(self):
+        s3_mock = _make_s3_mock()
+        helper = _make_helper(s3_mock)
+        helper.force_pip_packages = ["sentence-transformers"]
+
+        with (
+            patch("overture_airflow_provider.spark_agnostic_helpers.PyPiDownloader"),
+            patch(
+                "overture_airflow_provider.spark_agnostic_helpers.tempfile.mkdtemp",
+                return_value=tempfile.mkdtemp(),
+            ),
+        ):
+            _, _, _, native = helper.download_and_cache_python_packages(
+                py_pi_client=MagicMock(),
+                packages=["sentence-transformers==2.2.0"],
+                python_version="3.11",
+                cache_native_wheels=True,
+            )
+        assert native == ["sentence-transformers==2.2.0"]
+        assert len(s3_mock._uploaded) == 0
+
+    def test_flag_off_returns_pip_spec(self):
+        _, _, _, native, s3 = self._run(
+            wheel_files=[SEDONA_WHEEL],
+            requested_packages=["apache-sedona==1.7.2"],
+            cache_native_wheels=False,
+        )
+        assert native == ["apache-sedona==1.7.2"]
         assert len(s3._uploaded) == 0
 
 


### PR DESCRIPTION
## Incident context

Prod Glue job `overture_buildings.building_part_from_osm.BuildingPartFromOsm` (Glue 5.0, run `jr_2d0bf92268ad71ce1def2766fe9ad8d4515ba665561daf37c95e3ca2d3697706`) failed at bootstrap: `--additional-python-modules` pip-installed `apache-sedona` from **public PyPI**, and files.pythonhosted.org returned `HTTP 502 Server Error: Gateway Error`. The job never started; the next run succeeded — a transient PyPI outage was a single point of failure at Glue bootstrap.

Related: OvertureMaps/tf-data-platform#4866

## Change

The wheel is already downloaded from CodeArtifact on the MWAA worker (linux x86_64, matching Glue workers) — it was just being **deleted** and replaced with a bare `pkg==version` pip spec. Now:

- **`spark_agnostic_helpers.py`** — `download_and_cache_python_packages` gains an opt-in `cache_native_wheels: bool = False` flag. When set, explicitly-requested native wheels are cached in the shared S3 wheel cache (`python_wheels/codeartifact_cache`, same head_object-then-upload pattern as pure wheels) and returned as `s3://.../*.whl` URIs in the existing `native_packages` list. **Fallback:** any cache/upload failure logs a warning and falls back per-package to the previous `pkg==version` spec (PyPI at bootstrap).
- **`_glue.py`** — `download_python_packages_glue` passes `cache_native_wheels=True` (Glue's `--additional-python-modules` accepts S3 wheel paths directly). `build_glue_operator_kwargs` normalizes sedona detection (S3 wheel filenames use underscores: `apache_sedona-...whl`) and prefers the sedona entry from `native_packages` over `jar_info["sedona_module"]`, so sedona is listed exactly once.
- **Unchanged:** Wherobots/Databricks/render paths (flag defaults off; Wherobots keeps parsing `pkg==version` specs), `force_pip_packages` behavior, transitive native-dep skipping. No CodeArtifact tokens reach Glue job arguments — Glue reads the wheels via its IAM role.

## Tests

- `tests/test_spark_agnostic_helpers.py` — new `TestCacheNativeWheels`: cache miss uploads + returns S3 URI, cache hit skips upload, upload failure and non-404 head errors fall back to pip spec, transitive deps still skipped, force_pip stays a bare spec, flag off preserves old behavior.
- `tests/test_platform_handlers.py` — S3 sedona URI preferred over PyPI spec (no duplicate), spec fallback not duplicated, mixed sedona URI + numba spec.

`uv run pytest`: **531 passed** · `ruff check` / `ruff format --check`: clean.