### PR TITLE
[BUG] Stop pinning bundle_inspector's SQL highlighting to a synthesized CDN asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bundle_inspector`'s SQL syntax highlighting silently stopped working under
+  SRI-enforcing browsers.** The `index.html` template pinned an
+  `integrity` hash against `prismjs@1.29.0/prism.min.js`, but that path
+  isn't actually published by the `prismjs` npm package: the real tarball
+  ships only unminified `prism.js` at its root. `cdn.jsdelivr.net` was
+  synthesizing `prism.min.js` on the fly and caching the result, so its
+  bytes (and hash) could drift whenever jsdelivr's own minifier changed,
+  independent of the pinned package version. When that happened, the
+  browser rejected the stale hash with `Failed to find a valid digest in
+  the 'integrity' attribute`, and `prism-sql.min.js` then threw
+  `Uncaught ReferenceError: Prism is not defined`. Every other CDN asset in
+  that template (`maplibre-gl.js`, `themes/prism.min.css`,
+  `components/prism-sql.min.js`, `marked.min.js`) is a real file in its
+  package, so their hashes are safe to pin as-is; only the synthesized
+  `prism.min.js` wasn't. Dropped `integrity`/`crossorigin` from that one tag
+  instead of pinning against jsdelivr's derivative output: this is a
+  read-only internal dashboard, not a spot that warrants chasing a moving
+  hash for a minifier we don't control.
+
 ## [0.7.2] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-18
+
 ### Fixed
 
 - **`bundle_inspector`'s SQL syntax highlighting silently stopped working under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.7.2"
+version = "0.7.3"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/plugins/bundle_inspector/templates/bundle_inspector/index.html
+++ b/src/overture_airflow_provider/plugins/bundle_inspector/templates/bundle_inspector/index.html
@@ -10,7 +10,7 @@
     <script src="https://cdn.jsdelivr.net/npm/maplibre-gl@4.7.1/dist/maplibre-gl.js" integrity="sha384-SYKAG6cglRMN0RVvhNeBY0r3FYKNOJtznwA0v7B5Vp9tr31xAHsZC0DqkQ/pZDmj" crossorigin="anonymous"></script>
     <script type="importmap">{"imports":{"fflate":"https://cdn.jsdelivr.net/npm/fflate@0.8.2/+esm"}}</script>
     <script>const STATIC_BASE = "/bundle-inspector/static/";</script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" integrity="sha384-ZM8fDxYm+GXOWeJcxDetoRImNnEAS7XwVFH5kv0pT6RXNy92Nemw/Sj7NfciXpqg" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-sql.min.js" integrity="sha384-/MKWdycCDliku23mP5sYXbZNuXrzgmQO/jsVxwPFn99dVOaXRyKsqDjarqpueGAp" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js" integrity="sha384-H+hy9ULve6xfxRkWIh/YOtvDdpXgV2fmAGQkIDTxIgZwNoaoBal14Di2YTMR6MzR" crossorigin="anonymous"></script>
 </head>


### PR DESCRIPTION
Fixes #76.

`prismjs@1.29.0/prism.min.js` isn't a real file in the `prismjs` npm package: the tarball only ships unminified `prism.js` at its root. `cdn.jsdelivr.net` was synthesizing `prism.min.js` on request and caching the result, so its bytes (and pinned SRI hash) could drift whenever jsdelivr's own minifier changed, independent of the pinned package version. When that drifted, SRI-enforcing browsers rejected the stale hash and `prism-sql.min.js` threw `Uncaught ReferenceError: Prism is not defined`, breaking SQL syntax highlighting in the Athena/Parquet preview panes.

Verified every other CDN asset in `index.html` (`maplibre-gl.js`, `themes/prism.min.css`, `components/prism-sql.min.js`, `marked.min.js`) against its actual npm tarball: all are real, immutable files, safe to pin as-is. Dropped `integrity`/`crossorigin` from the `prism.min.js` tag instead of chasing jsdelivr's derivative output: `bundle_inspector` is a read-only internal dashboard, not worth pinning a hash we don't control.

## Testing

- `node --test tests/js/bundle_inspector_core.test.mjs` passes (no existing test covers this static HTML asset).
- `uv run ruff check .` passes.