### PR TITLE
[BUG] Stop hardcoding azure_attributes in Databricks cluster builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-19
+
+### Fixed
+
+- **`DatabricksConfig` always submitted `azure_attributes`, rejecting clusters
+  on AWS workspaces.** `setup_databricks_cluster` and
+  `DatabricksClusterSize.as_json` hardcoded that key with no `aws_attributes`
+  branch and no cloud detection, so the Databricks Clusters API rejected the
+  spec outright against an AWS workspace
+  (`airflow.exceptions.AirflowException: Spark job FAILED on DATABRICKS
+  (submit/config failure, likely a provider or configuration fault)`,
+  `databricks_base.py:615 ERROR - ... raised HTTPError`). Worker/driver
+  instance-type discovery had the same gap: it only returned Azure VM SKUs
+  (`Standard_E4a_v4`), so an AWS workspace got sized with SKUs it can't run.
+  Caught live in OvertureMaps/tf-data-platform#4779's CI smoke test against a
+  real AWS Databricks workspace (fixes #78).
+
+### Added
+
+- **`DatabricksConfig.cloud`**, so a caller running against an AWS or GCP
+  workspace can pin the target cloud explicitly (`"aws"`, `"azure"`, or
+  `"gcp"`). Defaults to `"azure"` (this provider's original, Azure-only
+  behavior), so existing callers are unaffected and never trigger a workspace
+  lookup. Set it to `""` to auto-detect instead, via the `databricks-sdk`'s
+  own environment detection (derived from the connection host, no API round
+  trip). Picks the cluster attributes key the Clusters API requires
+  (`aws_attributes` / `azure_attributes` / `gcp_attributes`) and, unless
+  `worker_instance_types`/`driver_node_type` are pinned, the default node-type
+  catalog for that cloud. `DatabricksClusterSize` now carries an
+  `aws_databricks_instance_types` catalog (`m5d.*` family) alongside the
+  existing Azure one, and `from_desired_cores`/`from_cluster_size` both take a
+  `cloud` kwarg.
+
 ## [0.7.3] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.7.3"
+version = "0.8.0"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -126,6 +126,53 @@ def discover_gpu_cluster_options(
     return result
 
 
+def discover_databricks_cloud(databricks_conn_id: str) -> str:
+    """Detect which cloud a Databricks workspace is hosted on.
+
+    Reads the ``databricks-sdk``'s own environment detection (derived from the
+    connection host, e.g. ``*.azuredatabricks.net`` vs. ``*.cloud.databricks.com``
+    — no API round trip), so callers don't have to plumb an explicit
+    ``aws``/``azure``/``gcp`` hint through Airflow Variables to pick the right
+    cluster attributes key (``aws_attributes`` vs. ``azure_attributes`` vs.
+    ``gcp_attributes``).
+
+    Returns ``"aws"``, ``"azure"``, or ``"gcp"``. Raises ``ValueError`` if the
+    workspace host doesn't resolve to a known cloud.
+    """
+    # Lazy import: the hook pulls in databricks-sdk / Airflow, both optional at
+    # package-import time.
+    from overture_airflow_provider.hooks import DatabricksSdkHook
+
+    with DatabricksSdkHook(databricks_conn_id).get_workspace_client() as client:
+        config = client.config
+        if config.is_aws:
+            return "aws"
+        if config.is_azure:
+            return "azure"
+        if config.is_gcp:
+            return "gcp"
+
+    raise ValueError(
+        f"Databricks connection {databricks_conn_id!r} host does not resolve to a "
+        "known cloud (aws/azure/gcp); set DatabricksConfig.cloud explicitly"
+    )
+
+
+def _resolve_databricks_cloud(setup_info: dict) -> str:
+    """Resolve the target cloud: explicit override wins, else auto-discover.
+
+    ``DatabricksConfig.cloud`` defaults to ``"azure"`` (this provider's
+    original, Azure-only behavior), so existing callers never trigger a
+    workspace lookup. Auto-discovery only runs when a caller explicitly sets
+    ``cloud=""`` to opt into it.
+    """
+    cloud = setup_info.get("databricks_cloud") or None
+    if cloud:
+        return cloud
+    conn_id = setup_info["databricks_conf"].get("databricks_conn_id", "databricks_default")
+    return discover_databricks_cloud(conn_id)
+
+
 def _resolve_databricks_node_config(setup_info: dict) -> dict:
     """Merge explicit Databricks node overrides with optional GPU discovery.
 
@@ -279,6 +326,7 @@ def setup_databricks_cluster(
     print(f"extra_spark_env_vars: {extra_spark_env_vars}")
 
     node_config = _resolve_databricks_node_config(setup_info)
+    cloud = _resolve_databricks_cloud(setup_info)
 
     databricks_spark_conf = setup_info.get("databricks_spark_conf", {}) or {}
     databricks_spark_env_vars = setup_info.get("databricks_spark_env_vars", {}) or {}
@@ -297,16 +345,12 @@ def setup_databricks_cluster(
             (int(spark_cluster_desired_workers) if spark_cluster_desired_workers else None),
             instance_types=node_config["worker_instance_types"],
             driver_node_type=node_config["driver_node_type"],
+            cloud=cloud,
         ),
         "spark_version": (node_config["spark_version"] or spark_impl.get_native_version()),
         "spark_conf": _merge_spark_conf(
             _DATABRICKS_SPARK_CONF_DEFAULTS, databricks_spark_conf, extra_spark_conf
         ),
-        "azure_attributes": {
-            "first_on_demand": 1,
-            "availability": "ON_DEMAND_AZURE",
-            "spot_bid_max_price": -1,
-        },
         "spark_env_vars": {
             "PIP_PRE": "true",
             "SPARK_JAR_PATHS": spark_jar_paths or "",

--- a/src/overture_airflow_provider/_setup.py
+++ b/src/overture_airflow_provider/_setup.py
@@ -128,6 +128,7 @@ def setup_spark_job(
         "databricks_driver_node_type": databricks_config.driver_node_type,
         "databricks_spark_version": databricks_config.spark_version,
         "databricks_gpu": databricks_config.gpu,
+        "databricks_cloud": databricks_config.cloud,
         "glue_execution_class": glue_config.execution_class,
         "glue_verbose": glue_config.verbose,
         "glue_output_log_group": glue_config.output_log_group,

--- a/src/overture_airflow_provider/cluster_sizing.py
+++ b/src/overture_airflow_provider/cluster_sizing.py
@@ -76,18 +76,82 @@ azure_databricks_instance_types = {
     "Standard_E96a_v4": 96,
 }
 
+# EC2 instance types carrying local NVMe storage (the AWS analogue of the
+# Azure "a"-series above), sized to roughly the same core ladder. Core counts
+# per size: https://aws.amazon.com/ec2/instance-types/m5/
+aws_databricks_instance_types = {
+    "m5d.xlarge": 4,
+    "m5d.2xlarge": 8,
+    "m5d.4xlarge": 16,
+    "m5d.8xlarge": 32,
+    "m5d.12xlarge": 48,
+    "m5d.16xlarge": 64,
+    "m5d.24xlarge": 96,
+}
+
+_DEFAULT_CLOUD = "azure"
+
 
 class DatabricksClusterSize:
+    # Per-cloud (driver, worker, number_of_workers) shortcuts for from_cluster_size.
     mapping = {
-        ClusterSize.XS: ("Standard_E4a_v4", "Standard_E4a_v4", 2),
-        ClusterSize.S: ("Standard_E4a_v4", "Standard_E8a_v4", 5),
-        ClusterSize.M: ("Standard_E4a_v4", "Standard_E8a_v4", 20),
-        ClusterSize.L: ("Standard_E4a_v4", "Standard_E16a_v4", 40),
-        ClusterSize.XL: ("Standard_E4a_v4", "Standard_E32a_v4", 64),
+        "azure": {
+            ClusterSize.XS: ("Standard_E4a_v4", "Standard_E4a_v4", 2),
+            ClusterSize.S: ("Standard_E4a_v4", "Standard_E8a_v4", 5),
+            ClusterSize.M: ("Standard_E4a_v4", "Standard_E8a_v4", 20),
+            ClusterSize.L: ("Standard_E4a_v4", "Standard_E16a_v4", 40),
+            ClusterSize.XL: ("Standard_E4a_v4", "Standard_E32a_v4", 64),
+        },
+        "aws": {
+            ClusterSize.XS: ("m5d.xlarge", "m5d.xlarge", 2),
+            ClusterSize.S: ("m5d.xlarge", "m5d.2xlarge", 5),
+            ClusterSize.M: ("m5d.xlarge", "m5d.2xlarge", 20),
+            ClusterSize.L: ("m5d.xlarge", "m5d.4xlarge", 40),
+            ClusterSize.XL: ("m5d.xlarge", "m5d.8xlarge", 64),
+        },
     }
 
+    _INSTANCE_TYPES = {
+        "azure": azure_databricks_instance_types,
+        "aws": aws_databricks_instance_types,
+    }
+    _DEFAULT_DRIVER = {"azure": "Standard_E4a_v4", "aws": "m5d.xlarge"}
+
     @classmethod
-    def as_json(cls, driver_node_type, worker_node_type, number_of_workers) -> dict:
+    def _cloud_attributes(cls, cloud: str) -> dict:
+        """Return the single cloud-specific attributes key the Clusters API accepts.
+
+        Databricks rejects a cluster spec carrying ``azure_attributes`` against
+        an AWS workspace (and vice versa), so exactly one of these keys must be
+        present, matching the workspace's actual cloud.
+        """
+        if cloud == "aws":
+            return {
+                "aws_attributes": {
+                    "first_on_demand": 1,
+                    "availability": "SPOT_WITH_FALLBACK",
+                    "zone_id": "auto",
+                    "spot_bid_price_percent": 100,
+                }
+            }
+        if cloud == "gcp":
+            return {
+                "gcp_attributes": {
+                    "availability": "PREEMPTIBLE_WITH_FALLBACK_GCP",
+                }
+            }
+        return {
+            "azure_attributes": {
+                "first_on_demand": 1,
+                "availability": "SPOT_WITH_FALLBACK_AZURE",
+                "spot_bid_max_price": -1,
+            }
+        }
+
+    @classmethod
+    def as_json(
+        cls, driver_node_type, worker_node_type, number_of_workers, cloud: str = _DEFAULT_CLOUD
+    ) -> dict:
         return {
             "node_type_id": worker_node_type,
             "driver_node_type_id": driver_node_type,
@@ -95,11 +159,7 @@ class DatabricksClusterSize:
                 "min_workers": number_of_workers,
                 "max_workers": number_of_workers,
             },
-            "azure_attributes": {
-                "first_on_demand": 1,
-                "availability": "SPOT_WITH_FALLBACK_AZURE",
-                "spot_bid_max_price": -1,
-            },
+            **cls._cloud_attributes(cloud),
         }
 
     @classmethod
@@ -110,20 +170,27 @@ class DatabricksClusterSize:
         *,
         instance_types: dict | None = None,
         driver_node_type: str | None = None,
+        cloud: str = _DEFAULT_CLOUD,
     ) -> dict:
-        driver_node_type = driver_node_type or "Standard_E4a_v4"
+        driver_node_type = driver_node_type or cls._DEFAULT_DRIVER.get(
+            cloud, cls._DEFAULT_DRIVER[_DEFAULT_CLOUD]
+        )
         worker_node_type, number_of_workers = InstanceCalculator.calculate_instances(
             min_instance_count=1,
             desired_cores=desired_cores,
-            instance_types=instance_types or azure_databricks_instance_types,
+            instance_types=(
+                instance_types
+                or cls._INSTANCE_TYPES.get(cloud, cls._INSTANCE_TYPES[_DEFAULT_CLOUD])
+            ),
             desired_workers=desired_workers,
         )
-        return cls.as_json(driver_node_type, worker_node_type, number_of_workers)
+        return cls.as_json(driver_node_type, worker_node_type, number_of_workers, cloud=cloud)
 
     @classmethod
-    def from_cluster_size(cls, cluster_size: ClusterSize) -> dict:
-        driver_node_type, worker_node_type, number_of_workers = cls.mapping[cluster_size]
-        return cls.as_json(driver_node_type, worker_node_type, number_of_workers)
+    def from_cluster_size(cls, cluster_size: ClusterSize, cloud: str = _DEFAULT_CLOUD) -> dict:
+        cloud_mapping = cls.mapping.get(cloud, cls.mapping[_DEFAULT_CLOUD])
+        driver_node_type, worker_node_type, number_of_workers = cloud_mapping[cluster_size]
+        return cls.as_json(driver_node_type, worker_node_type, number_of_workers, cloud=cloud)
 
 
 # Wherobots ----------------------------------------------------------------

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -360,6 +360,17 @@ class DatabricksConfig:
             (explicit node/GPU count) over ``spark_cluster_desired_worker_cores``;
             core-based sizing is an indirect proxy for GPUs and assumes a fixed
             cores-per-GPU node shape.
+        cloud: Which cloud the target workspace runs on: ``"aws"``, ``"azure"``,
+            or ``"gcp"``. Picks the cluster attributes key the Clusters API
+            requires (``aws_attributes`` / ``azure_attributes`` /
+            ``gcp_attributes``) and, unless ``worker_instance_types`` /
+            ``driver_node_type`` are pinned, the default node-type catalog.
+            Defaults to ``"azure"`` (this provider's original, Azure-only
+            behavior), so existing Azure callers are unaffected. Set this to
+            ``"aws"``/``"gcp"`` explicitly, or to ``""`` to auto-detect from
+            the workspace connection's host via the ``databricks-sdk`` (no API
+            round trip; requires the ``[databricks]`` extra and a reachable
+            connection at setup time).
     """
 
     cluster_conf: dict[str, Any] = field(default_factory=dict)
@@ -374,6 +385,7 @@ class DatabricksConfig:
     driver_node_type: str = ""
     spark_version: str = ""
     gpu: bool = False
+    cloud: str = "azure"
 
 
 @dataclass

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -210,6 +210,7 @@ def _build_render_setup_info(
         "databricks_driver_node_type": databricks_config.driver_node_type,
         "databricks_spark_version": databricks_config.spark_version,
         "databricks_gpu": databricks_config.gpu,
+        "databricks_cloud": databricks_config.cloud,
         "glue_execution_class": glue_config.execution_class,
         "glue_verbose": glue_config.verbose,
         "glue_output_log_group": glue_config.output_log_group,

--- a/src/overture_airflow_provider/setup_info.py
+++ b/src/overture_airflow_provider/setup_info.py
@@ -54,6 +54,7 @@ SERIALIZABLE_KEYS = (
     "databricks_driver_node_type",
     "databricks_spark_version",
     "databricks_gpu",
+    "databricks_cloud",
     "glue_execution_class",
     "glue_verbose",
     "glue_output_log_group",

--- a/tests/test_cluster_sizing.py
+++ b/tests/test_cluster_sizing.py
@@ -4,6 +4,7 @@ import pytest
 
 from overture_airflow_provider.cluster_sizing import (
     AwsGlueClusterSize,
+    ClusterSize,
     DatabricksClusterSize,
     InstanceCalculator,
 )
@@ -158,6 +159,61 @@ def test_databricks_from_cluster_size():
     result = DatabricksClusterSize.from_cluster_size(ClusterSize.S)
     assert result["node_type_id"] == "Standard_E8a_v4"
     assert result["autoscale"]["min_workers"] == 5
+
+
+# ─── cloud-specific attributes (#78) ──────────────────────────────────────────
+
+
+class TestDatabricksClusterSizeCloudAttributes:
+    """Databricks rejects a cluster spec carrying the wrong cloud's attributes
+    key (e.g. `azure_attributes` on an AWS workspace), so exactly one of
+    `aws_attributes`/`azure_attributes`/`gcp_attributes` must be present and it
+    must match the target workspace's cloud.
+    """
+
+    def test_default_cloud_is_azure(self):
+        result = DatabricksClusterSize.from_desired_cores(40)
+        assert "azure_attributes" in result
+        assert "aws_attributes" not in result
+        assert "gcp_attributes" not in result
+
+    def test_aws_cloud_uses_aws_attributes_and_ec2_catalog(self):
+        result = DatabricksClusterSize.from_desired_cores(40, cloud="aws")
+        assert "aws_attributes" in result
+        assert "azure_attributes" not in result
+        assert result["node_type_id"] in {
+            "m5d.xlarge",
+            "m5d.2xlarge",
+            "m5d.4xlarge",
+            "m5d.8xlarge",
+            "m5d.12xlarge",
+            "m5d.16xlarge",
+            "m5d.24xlarge",
+        }
+        assert result["driver_node_type_id"] == "m5d.xlarge"
+
+    def test_gcp_cloud_uses_gcp_attributes(self):
+        result = DatabricksClusterSize.from_desired_cores(
+            40, instance_types={"n1-standard-8": 8}, cloud="gcp"
+        )
+        assert "gcp_attributes" in result
+        assert "aws_attributes" not in result
+        assert "azure_attributes" not in result
+
+    def test_explicit_instance_types_win_over_cloud_default_catalog(self):
+        # A caller-supplied catalog (e.g. pinned GPU SKUs) still applies
+        # regardless of which cloud's attributes key gets set.
+        result = DatabricksClusterSize.from_desired_cores(
+            32, instance_types={"my.custom.sku": 8}, cloud="aws"
+        )
+        assert result["node_type_id"] == "my.custom.sku"
+        assert "aws_attributes" in result
+
+    def test_from_cluster_size_aws(self):
+        result = DatabricksClusterSize.from_cluster_size(ClusterSize.S, cloud="aws")
+        assert result["node_type_id"] == "m5d.2xlarge"
+        assert result["driver_node_type_id"] == "m5d.xlarge"
+        assert "aws_attributes" in result
 
 
 def test_wherobots_from_desired_cores_all_branches():

--- a/tests/test_databricks_gpu.py
+++ b/tests/test_databricks_gpu.py
@@ -7,7 +7,9 @@ import pytest
 
 import overture_airflow_provider._databricks as dbx
 from overture_airflow_provider._databricks import (
+    _resolve_databricks_cloud,
     _resolve_databricks_node_config,
+    discover_databricks_cloud,
     discover_gpu_cluster_options,
 )
 
@@ -59,6 +61,84 @@ def _patch_workspace(monkeypatch, clusters):
         "overture_airflow_provider._airflow_compat.BaseHook.get_connection",
         staticmethod(lambda conn_id: _Conn()),
     )
+
+
+def _patch_workspace_config(monkeypatch, *, is_aws=False, is_azure=False, is_gcp=False):
+    """Patch `DatabricksSdkHook.get_workspace_client` to yield a client whose
+    `.config` reports the given cloud, mirroring the databricks-sdk's own
+    host-derived `Config.is_aws`/`is_azure`/`is_gcp` properties.
+    """
+    fake_config = types.SimpleNamespace(is_aws=is_aws, is_azure=is_azure, is_gcp=is_gcp)
+
+    @contextmanager
+    def _fake_workspace_client(self):
+        yield types.SimpleNamespace(config=fake_config)
+
+    monkeypatch.setattr(
+        "overture_airflow_provider.hooks.DatabricksSdkHook.get_workspace_client",
+        _fake_workspace_client,
+    )
+
+    class _Conn:
+        host = "https://example.cloud.databricks.com"
+        login = None
+        password = "token"
+        extra_dejson = {}
+
+    monkeypatch.setattr(
+        "overture_airflow_provider._airflow_compat.BaseHook.get_connection",
+        staticmethod(lambda conn_id: _Conn()),
+    )
+
+
+class TestDiscoverDatabricksCloud:
+    def test_detects_aws(self, monkeypatch):
+        _patch_workspace_config(monkeypatch, is_aws=True)
+        assert discover_databricks_cloud("databricks_default") == "aws"
+
+    def test_detects_azure(self, monkeypatch):
+        _patch_workspace_config(monkeypatch, is_azure=True)
+        assert discover_databricks_cloud("databricks_default") == "azure"
+
+    def test_detects_gcp(self, monkeypatch):
+        _patch_workspace_config(monkeypatch, is_gcp=True)
+        assert discover_databricks_cloud("databricks_default") == "gcp"
+
+    def test_raises_on_unknown_cloud(self, monkeypatch):
+        _patch_workspace_config(monkeypatch)
+        with pytest.raises(ValueError, match="does not resolve to a known cloud"):
+            discover_databricks_cloud("databricks_default")
+
+
+class TestResolveDatabricksCloud:
+    def test_explicit_cloud_skips_discovery(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            dbx, "discover_databricks_cloud", lambda conn_id: calls.append(conn_id) or "aws"
+        )
+        result = _resolve_databricks_cloud({"databricks_cloud": "gcp", "databricks_conf": {}})
+        assert result == "gcp"
+        assert calls == []
+
+    def test_empty_cloud_triggers_discovery(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            dbx, "discover_databricks_cloud", lambda conn_id: calls.append(conn_id) or "aws"
+        )
+        result = _resolve_databricks_cloud(
+            {"databricks_cloud": "", "databricks_conf": {"databricks_conn_id": "my_conn"}}
+        )
+        assert result == "aws"
+        assert calls == ["my_conn"]
+
+    def test_discovery_defaults_conn_id(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            dbx, "discover_databricks_cloud", lambda conn_id: calls.append(conn_id) or "azure"
+        )
+        result = _resolve_databricks_cloud({"databricks_conf": {}})
+        assert result == "azure"
+        assert calls == ["databricks_default"]
 
 
 class TestDiscoverGpuClusterOptions:

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -112,6 +112,7 @@ def _databricks_setup_info():
         "wherobots_external_id": "",
         "aws_region": "us-east-1",
         "databricks_conf": {"databricks_conn_id": "databricks_default"},
+        "databricks_cloud": "azure",
         "glue_execution_class": "STANDARD",
         "iam_role_name": "AWSGlueServiceRole",
     }
@@ -1018,6 +1019,45 @@ class TestDatabricksSetupCluster:
         assert cluster["node_type_id"] == "Standard_NC8as_T4_v3"
         assert cluster["driver_node_type_id"] == "Standard_NC8as_T4_v3"
         assert cluster["spark_version"] == "15.4.x-gpu-ml-scala2.12"
+
+    def test_aws_cloud_sets_aws_attributes_and_ec2_worker_type(self):
+        # Regression for #78: the cluster builder used to hardcode
+        # azure_attributes with no aws_attributes branch, which Databricks
+        # rejects outright on an AWS workspace.
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = "aws"
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        cluster = result["new_cluster"]
+        assert "aws_attributes" in cluster
+        assert "azure_attributes" not in cluster
+        assert cluster["node_type_id"].startswith("m5d.")
+
+    def test_cloud_discovery_fills_in_when_unset(self, monkeypatch):
+        import overture_airflow_provider._databricks as dbx
+
+        monkeypatch.setattr(dbx, "discover_databricks_cloud", lambda conn_id: "aws")
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = ""
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        assert "aws_attributes" in result["new_cluster"]
 
     def test_download_python_packages_returns_none(self):
         handler = DatabricksPlatformHandler(_databricks_setup_info())


### PR DESCRIPTION
`setup_databricks_cluster` built `new_cluster` with `azure_attributes` hardcoded. Databricks' Clusters API rejects a spec carrying the wrong cloud's attributes key, so any AWS Databricks workspace failed cluster creation outright, fixes #78.

`DatabricksClusterSize` now picks `aws_attributes`, `azure_attributes`, or `gcp_attributes` off a new `DatabricksConfig.cloud` field, and ships an AWS EC2 ([m5d.* family](https://aws.amazon.com/ec2/instance-types/m5/)) instance-type catalog alongside the existing Azure one. `cloud` defaults to `"azure"`, this provider's original behavior, so existing callers see no change and no live workspace call. Set `cloud=""` to opt into auto-detection instead, via the `databricks-sdk`'s own workspace config (`is_aws`/`is_azure`/`is_gcp`, derived from the connection host, no API round trip).

`databricks_cloud` is threaded through `_setup.py`, `setup_info.SERIALIZABLE_KEYS`, and `render.py` so it round-trips through XCom and stays available in the offline render path that has no live Airflow connections.

## Testing

Added:
- `TestDatabricksClusterSizeCloudAttributes` in `tests/test_cluster_sizing.py`: default-is-azure, AWS attributes plus EC2 catalog, GCP attributes, explicit instance-type override wins, `from_cluster_size` AWS variant.
- `TestDiscoverDatabricksCloud`/`TestResolveDatabricksCloud` in `tests/test_databricks_gpu.py`: AWS/Azure/GCP detection, unknown-cloud raises, explicit `cloud` skips discovery, empty `cloud` triggers it.
- `test_aws_cloud_sets_aws_attributes_and_ec2_worker_type`/`test_cloud_discovery_fills_in_when_unset` in `tests/test_platform_handlers.py`, end to end through `setup_databricks_cluster`.

Full suite (546 tests), `ruff check`, and `ruff format --check` pass locally.

<!--:robot:-->