### PR TITLE
[BUG] Stop hardcoding Wherobots version="preview"; target GA runtime by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,11 @@ override fields avoids the workspace call (and its auth) entirely.
 
 AWS region field is `aws_region` (not `region`).
 
+`version` (default `None`) is the Wherobots run-API runtime channel: `None`
+omits the field so submissions target the GA runtime. Only set it (e.g.
+`"preview"`) deliberately — the preview stack runs Spark 4 / Scala 2.13 and
+cannot load Scala 2.12 JARs.
+
 ### Cluster sizing classes
 
 `AwsGlueClusterSize` / `DatabricksClusterSize` / `WherobotsClusterSize` are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,10 +108,10 @@ override fields avoids the workspace call (and its auth) entirely.
 
 AWS region field is `aws_region` (not `region`).
 
-`version` (default `None`) is the Wherobots run-API runtime channel: `None`
-omits the field so submissions target the GA runtime. Only set it (e.g.
-`"preview"`) deliberately — the preview stack runs Spark 4 / Scala 2.13 and
-cannot load Scala 2.12 JARs.
+`version` (default `"latest"`) is the Wherobots run-API runtime channel:
+`"latest"` targets the stable runtime (the API's own default). Only set
+`"preview"` deliberately — the preview stack runs Spark 4 / Scala 2.13 and
+cannot load Scala 2.12 JARs. `None` omits the field from submissions.
 
 ### Cluster sizing classes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   hardcoded `version="preview"`, which resolves to the WherobotsDB 2.x stack
   (Spark 4 / Scala 2.13) — but `SparkImpl.WHEROBOTS_v1_5_0` declares
   Spark 3.5 / Scala 2.12, so any Scala 2.12 JAR died at driver class-load
-  time (Python jobs happened to survive, masking the bug). The run-API
-  `version` is now derived from the selected `SparkImpl`
-  (`wherobots_run_version`): WherobotsDB 1.x impls omit the field so the API
-  targets the GA runtime, and a future 2.x impl maps to `"preview"`.
-  `build_wherobots_operator_kwargs` / `execute_wherobots_job` still accept an
-  explicit `version=` override. (#81)
+  time (Python jobs happened to survive, masking the bug). Submissions now
+  omit the run-API `version` field by default so they target the GA runtime.
+  Callers can still opt into another channel explicitly via the new
+  `WherobotsConfig.version` field (e.g. `"preview"`), or per-call via the
+  existing `version=` argument on `build_wherobots_operator_kwargs` /
+  `execute_wherobots_job`. (#81)
 
 ## [0.7.3] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-24
+
 ### Fixed
 
 - **Scala jobs failed on Wherobots with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   target the stable runtime by default via the new `WherobotsConfig.version`
   field, which defaults to `"latest"` (the run API's own default). Set it to
   `"preview"` to opt into the preview channel deliberately, or `None` to omit
-  the field from the submission; the existing `version=` argument on
-  `build_wherobots_operator_kwargs` / `execute_wherobots_job` still wins
-  per-call. The `wherobots` extra now requires
+  the field from the submission; the config field is the single source of
+  truth for the runtime channel (the internal `version=` pass-through
+  argument was removed). The `wherobots` extra now requires
   `airflow-providers-wherobots>=1.4.3`, the first release whose operator
   accepts the `version` kwarg (already an implicit requirement of the old
   hardcoded value). (#81)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (Spark 4 / Scala 2.13) — but `SparkImpl.WHEROBOTS_v1_5_0` declares
   Spark 3.5 / Scala 2.12, so any Scala 2.12 JAR died at driver class-load
   time (Python jobs happened to survive, masking the bug). Submissions now
-  omit the run-API `version` field by default so they target the GA runtime.
-  Callers can still opt into another channel explicitly via the new
-  `WherobotsConfig.version` field (e.g. `"preview"`), or per-call via the
-  existing `version=` argument on `build_wherobots_operator_kwargs` /
-  `execute_wherobots_job`. (#81)
+  target the stable runtime by default via the new `WherobotsConfig.version`
+  field, which defaults to `"latest"` (the run API's own default). Set it to
+  `"preview"` to opt into the preview channel deliberately, or `None` to omit
+  the field from the submission; the existing `version=` argument on
+  `build_wherobots_operator_kwargs` / `execute_wherobots_job` still wins
+  per-call. The `wherobots` extra now requires
+  `airflow-providers-wherobots>=1.4.3`, the first release whose operator
+  accepts the `version` kwarg (already an implicit requirement of the old
+  hardcoded value). (#81)
 
 ## [0.7.3] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scala jobs failed on Wherobots with
+  `NoClassDefFoundError: scala/Serializable`.** Every Wherobots submission
+  hardcoded `version="preview"`, which resolves to the WherobotsDB 2.x stack
+  (Spark 4 / Scala 2.13) — but `SparkImpl.WHEROBOTS_v1_5_0` declares
+  Spark 3.5 / Scala 2.12, so any Scala 2.12 JAR died at driver class-load
+  time (Python jobs happened to survive, masking the bug). The run-API
+  `version` is now derived from the selected `SparkImpl`
+  (`wherobots_run_version`): WherobotsDB 1.x impls omit the field so the API
+  targets the GA runtime, and a future 2.x impl maps to `"preview"`.
+  `build_wherobots_operator_kwargs` / `execute_wherobots_job` still accept an
+  explicit `version=` override. (#81)
+
 ## [0.7.3] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.7.3"
+version = "0.8.0"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,12 @@ dependencies = [
 
 [project.optional-dependencies]
 databricks = ["apache-airflow-providers-databricks", "databricks-sdk"]
-wherobots = ["airflow-providers-wherobots"]
+wherobots = ["airflow-providers-wherobots>=1.4.3"]
 bundle-inspector = ["pyarrow", "shapely"]
 all = [
     "apache-airflow-providers-databricks",
     "databricks-sdk",
-    "airflow-providers-wherobots",
+    "airflow-providers-wherobots>=1.4.3",
     "pyarrow",
     "shapely",
 ]

--- a/src/overture_airflow_provider/_setup.py
+++ b/src/overture_airflow_provider/_setup.py
@@ -113,6 +113,7 @@ def setup_spark_job(
         "runner_script_overrides": dict(artifact_store.runner_script_overrides),
         "wherobots_external_id": wherobots_config.external_id,
         "wherobots_role_arn": wherobots_config.role_arn,
+        "wherobots_version": wherobots_config.version,
         "aws_region": wherobots_config.aws_region,
         "databricks_conf": databricks_config.cluster_conf,
         "databricks_extra_libraries": list(databricks_config.extra_libraries),

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -284,9 +284,10 @@ def build_wherobots_operator_kwargs(
     in which case the raw AWS region string is returned in ``region``).
 
     ``version=None`` (the default) uses the caller's ``WherobotsConfig.version``
-    override from ``setup_info`` when set, otherwise the field is omitted so
-    submissions target the GA runtime. Pass a string (e.g. ``"preview"``) to
-    force a specific runtime channel.
+    from ``setup_info``: ``"latest"`` (the config default, and the API's own
+    default) targets the stable GA runtime; ``"preview"`` opts into the
+    preview channel; a ``None``/empty config value omits the field entirely.
+    Pass a string here to force a specific channel per-call.
 
     Returns ``{"operator_kwargs", "submit_payload"}``. ``submit_payload`` is
     the JSON-serialisable equivalent used by the Wherobots REST API / CLI.
@@ -443,8 +444,8 @@ def execute_wherobots_job(
 ) -> dict:
     """Submit and wait for a Wherobots job.
 
-    ``version=None`` targets the GA runtime unless the caller opted into
-    another channel via ``WherobotsConfig.version``.
+    ``version=None`` uses the runtime channel from ``WherobotsConfig.version``
+    (``"latest"`` by default).
     """
     if not WHEROBOTS_AVAILABLE:
         raise ImportError("Wherobots dependencies are not installed")

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -5,6 +5,7 @@ import re
 import shutil
 
 from overture_airflow_provider.cluster_sizing import WherobotsClusterSize
+from overture_airflow_provider.spark import SparkImpl
 from overture_airflow_provider.spark_agnostic_helpers import SparkAgnosticHelper
 from overture_airflow_provider.spark_platform_handlers import registered_catalog_names
 
@@ -20,6 +21,24 @@ except ImportError:
 MAX_TIMEOUT_HOURS = 8
 WHEROBOTS_PROVIDER = "com.wherobots.awssdk.auth.WherobotsAssumeRoleCredentialsProvider"
 _API_SUBDOMAIN_PREFIX = "api."
+
+
+def wherobots_run_version(native_version: str) -> str | None:
+    """Map a ``SparkImpl``'s WherobotsDB version to the run-API ``version`` field.
+
+    WherobotsDB 1.x is the GA runtime (Spark 3.5 / Scala 2.12): return ``None``
+    so the field is omitted from the submission and the API targets GA.
+    WherobotsDB 2.x (Spark 4 / Scala 2.13) is currently only published as the
+    ``"preview"`` channel; revisit this mapping when 2.x goes GA.
+
+    Submitting a Scala 2.12 JAR to the 2.x runtime fails at class-load time
+    (``NoClassDefFoundError: scala/Serializable``), so the version must follow
+    the impl's declared Spark/Scala versions rather than being hardcoded.
+    """
+    major = native_version.split(".", 1)[0]
+    if major.isdigit() and int(major) >= 2:
+        return "preview"
+    return None
 
 
 def _build_agnostic_xcom_payload(setup_info: dict, *, job_url: str) -> str:
@@ -274,7 +293,7 @@ def build_wherobots_operator_kwargs(
     spark_cluster_desired_workers: str,
     wherobots_role_arn: str,
     task_id: str,
-    version: str = "preview",
+    version: str | None = None,
     resolve_region: bool = True,
 ) -> dict:
     """Pure-Python assembly of WherobotsRunOperator kwargs.
@@ -283,9 +302,19 @@ def build_wherobots_operator_kwargs(
     enum (set ``resolve_region=False`` to skip when the SDK isn't installed,
     in which case the raw AWS region string is returned in ``region``).
 
+    ``version=None`` (the default) derives the run-API ``version`` from the
+    selected ``SparkImpl`` (see :func:`wherobots_run_version`); pass a string
+    to force a specific runtime channel. When the derived/forced value is
+    ``None`` the field is omitted so the API targets the GA runtime.
+
     Returns ``{"operator_kwargs", "submit_payload"}``. ``submit_payload`` is
     the JSON-serialisable equivalent used by the Wherobots REST API / CLI.
     """
+    if version is None:
+        version = wherobots_run_version(
+            SparkImpl.from_str(setup_info["spark_impl_name"]).get_native_version()
+        )
+
     my_parameters = setup_info["parameters"]
 
     python_packages_or_jars_list = list(package_info["python_packages_or_jars_list"])
@@ -385,13 +414,14 @@ def build_wherobots_operator_kwargs(
         "task_id": task_id,
         "name": name,
         "runtime": runtime_name,
-        "version": version,
         "poll_logs": poll_logs,
         "polling_interval": polling_interval,
         "timeout_seconds": (3600 * MAX_TIMEOUT_HOURS),
         "region": region_val,
         "environment": environment,
     }
+    if version is not None:
+        operator_kwargs["version"] = version
     if run_jar is not None:
         operator_kwargs["run_jar"] = run_jar
     if run_python is not None:
@@ -401,10 +431,11 @@ def build_wherobots_operator_kwargs(
     submit_payload = {
         "name": name,
         "runtime": runtime_name,
-        "version": version,
         "region": setup_info["aws_region"],
         "environment": environment,
     }
+    if version is not None:
+        submit_payload["version"] = version
     if run_jar is not None:
         submit_payload["run_jar"] = run_jar
     if run_python is not None:
@@ -429,9 +460,13 @@ def execute_wherobots_job(
     wherobots_role_arn: str,
     task_id: str,
     context,
-    version: str = "preview",
+    version: str | None = None,
 ) -> dict:
-    """Submit and wait for a Wherobots job."""
+    """Submit and wait for a Wherobots job.
+
+    ``version=None`` derives the runtime channel from the selected
+    ``SparkImpl`` (see :func:`wherobots_run_version`).
+    """
     if not WHEROBOTS_AVAILABLE:
         raise ImportError("Wherobots dependencies are not installed")
 

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -274,7 +274,6 @@ def build_wherobots_operator_kwargs(
     spark_cluster_desired_workers: str,
     wherobots_role_arn: str,
     task_id: str,
-    version: str | None = None,
     resolve_region: bool = True,
 ) -> dict:
     """Pure-Python assembly of WherobotsRunOperator kwargs.
@@ -283,17 +282,16 @@ def build_wherobots_operator_kwargs(
     enum (set ``resolve_region=False`` to skip when the SDK isn't installed,
     in which case the raw AWS region string is returned in ``region``).
 
-    ``version=None`` (the default) uses the caller's ``WherobotsConfig.version``
-    from ``setup_info``: ``"latest"`` (the config default, and the API's own
-    default) targets the stable GA runtime; ``"preview"`` opts into the
-    preview channel; a ``None``/empty config value omits the field entirely.
-    Pass a string here to force a specific channel per-call.
+    The run-API ``version`` (runtime channel) comes from
+    ``WherobotsConfig.version`` via ``setup_info["wherobots_version"]``:
+    ``"latest"`` (the config default, and the API's own default) targets the
+    stable GA runtime; ``"preview"`` opts into the preview channel; a
+    ``None``/empty/missing value omits the field entirely.
 
     Returns ``{"operator_kwargs", "submit_payload"}``. ``submit_payload`` is
     the JSON-serialisable equivalent used by the Wherobots REST API / CLI.
     """
-    if version is None:
-        version = setup_info.get("wherobots_version") or None
+    version = setup_info.get("wherobots_version") or None
 
     my_parameters = setup_info["parameters"]
 
@@ -440,12 +438,11 @@ def execute_wherobots_job(
     wherobots_role_arn: str,
     task_id: str,
     context,
-    version: str | None = None,
 ) -> dict:
     """Submit and wait for a Wherobots job.
 
-    ``version=None`` uses the runtime channel from ``WherobotsConfig.version``
-    (``"latest"`` by default).
+    The runtime channel comes from ``WherobotsConfig.version`` (``"latest"``
+    by default) via ``setup_info["wherobots_version"]``.
     """
     if not WHEROBOTS_AVAILABLE:
         raise ImportError("Wherobots dependencies are not installed")
@@ -462,7 +459,6 @@ def execute_wherobots_job(
         spark_cluster_desired_workers=spark_cluster_desired_workers,
         wherobots_role_arn=wherobots_role_arn,
         task_id=task_id,
-        version=version,
         resolve_region=True,
     )
 

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -286,10 +286,7 @@ def build_wherobots_operator_kwargs(
     ``version=None`` (the default) uses the caller's ``WherobotsConfig.version``
     override from ``setup_info`` when set, otherwise the field is omitted so
     submissions target the GA runtime. Pass a string (e.g. ``"preview"``) to
-    force a specific runtime channel. The GA runtime matches what
-    ``SparkImpl.WHEROBOTS_v1_5_0`` declares (Spark 3.5 / Scala 2.12); the
-    preview channel runs Spark 4 / Scala 2.13, which cannot load Scala 2.12
-    JARs (``NoClassDefFoundError: scala/Serializable``).
+    force a specific runtime channel.
 
     Returns ``{"operator_kwargs", "submit_payload"}``. ``submit_payload`` is
     the JSON-serialisable equivalent used by the Wherobots REST API / CLI.

--- a/src/overture_airflow_provider/_wherobots.py
+++ b/src/overture_airflow_provider/_wherobots.py
@@ -5,7 +5,6 @@ import re
 import shutil
 
 from overture_airflow_provider.cluster_sizing import WherobotsClusterSize
-from overture_airflow_provider.spark import SparkImpl
 from overture_airflow_provider.spark_agnostic_helpers import SparkAgnosticHelper
 from overture_airflow_provider.spark_platform_handlers import registered_catalog_names
 
@@ -21,24 +20,6 @@ except ImportError:
 MAX_TIMEOUT_HOURS = 8
 WHEROBOTS_PROVIDER = "com.wherobots.awssdk.auth.WherobotsAssumeRoleCredentialsProvider"
 _API_SUBDOMAIN_PREFIX = "api."
-
-
-def wherobots_run_version(native_version: str) -> str | None:
-    """Map a ``SparkImpl``'s WherobotsDB version to the run-API ``version`` field.
-
-    WherobotsDB 1.x is the GA runtime (Spark 3.5 / Scala 2.12): return ``None``
-    so the field is omitted from the submission and the API targets GA.
-    WherobotsDB 2.x (Spark 4 / Scala 2.13) is currently only published as the
-    ``"preview"`` channel; revisit this mapping when 2.x goes GA.
-
-    Submitting a Scala 2.12 JAR to the 2.x runtime fails at class-load time
-    (``NoClassDefFoundError: scala/Serializable``), so the version must follow
-    the impl's declared Spark/Scala versions rather than being hardcoded.
-    """
-    major = native_version.split(".", 1)[0]
-    if major.isdigit() and int(major) >= 2:
-        return "preview"
-    return None
 
 
 def _build_agnostic_xcom_payload(setup_info: dict, *, job_url: str) -> str:
@@ -302,18 +283,19 @@ def build_wherobots_operator_kwargs(
     enum (set ``resolve_region=False`` to skip when the SDK isn't installed,
     in which case the raw AWS region string is returned in ``region``).
 
-    ``version=None`` (the default) derives the run-API ``version`` from the
-    selected ``SparkImpl`` (see :func:`wherobots_run_version`); pass a string
-    to force a specific runtime channel. When the derived/forced value is
-    ``None`` the field is omitted so the API targets the GA runtime.
+    ``version=None`` (the default) uses the caller's ``WherobotsConfig.version``
+    override from ``setup_info`` when set, otherwise the field is omitted so
+    submissions target the GA runtime. Pass a string (e.g. ``"preview"``) to
+    force a specific runtime channel. The GA runtime matches what
+    ``SparkImpl.WHEROBOTS_v1_5_0`` declares (Spark 3.5 / Scala 2.12); the
+    preview channel runs Spark 4 / Scala 2.13, which cannot load Scala 2.12
+    JARs (``NoClassDefFoundError: scala/Serializable``).
 
     Returns ``{"operator_kwargs", "submit_payload"}``. ``submit_payload`` is
     the JSON-serialisable equivalent used by the Wherobots REST API / CLI.
     """
     if version is None:
-        version = wherobots_run_version(
-            SparkImpl.from_str(setup_info["spark_impl_name"]).get_native_version()
-        )
+        version = setup_info.get("wherobots_version") or None
 
     my_parameters = setup_info["parameters"]
 
@@ -464,8 +446,8 @@ def execute_wherobots_job(
 ) -> dict:
     """Submit and wait for a Wherobots job.
 
-    ``version=None`` derives the runtime channel from the selected
-    ``SparkImpl`` (see :func:`wherobots_run_version`).
+    ``version=None`` targets the GA runtime unless the caller opted into
+    another channel via ``WherobotsConfig.version``.
     """
     if not WHEROBOTS_AVAILABLE:
         raise ImportError("Wherobots dependencies are not installed")

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -387,11 +387,18 @@ class WherobotsConfig:
         external_id: External ID for the cross-account assume-role call.
         aws_region: AWS region used for Iceberg credential config and for
             resolving the Wherobots run region.
+        version: Optional Wherobots run-API ``version`` (runtime channel).
+            ``None`` (default) omits the field so submissions target the GA
+            runtime. Set e.g. ``"preview"`` to opt into the preview channel —
+            note the preview stack may run a different Spark/Scala version
+            than the selected ``SparkImpl`` declares (Scala 2.12 JARs fail to
+            load on the Scala 2.13 preview runtime).
     """
 
     role_arn: str = ""
     external_id: str = ""
     aws_region: str = "us-east-1"
+    version: str | None = None
 
 
 @dataclass

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -387,18 +387,19 @@ class WherobotsConfig:
         external_id: External ID for the cross-account assume-role call.
         aws_region: AWS region used for Iceberg credential config and for
             resolving the Wherobots run region.
-        version: Optional Wherobots run-API ``version`` (runtime channel).
-            ``None`` (default) omits the field so submissions target the GA
-            runtime. Set e.g. ``"preview"`` to opt into the preview channel —
-            note the preview stack may run a different Spark/Scala version
-            than the selected ``SparkImpl`` declares (Scala 2.12 JARs fail to
-            load on the Scala 2.13 preview runtime).
+        version: Wherobots run-API ``version`` (runtime channel). Defaults to
+            ``"latest"``, the stable GA runtime (the API's own default). Set
+            ``"preview"`` to opt into the preview channel — note the preview
+            stack may run a different Spark/Scala version than the selected
+            ``SparkImpl`` declares (Scala 2.12 JARs fail to load on the
+            Scala 2.13 preview runtime). Set ``None`` to omit the field from
+            the submission entirely.
     """
 
     role_arn: str = ""
     external_id: str = ""
     aws_region: str = "us-east-1"
-    version: str | None = None
+    version: str | None = "latest"
 
 
 @dataclass

--- a/src/overture_airflow_provider/render.py
+++ b/src/overture_airflow_provider/render.py
@@ -195,6 +195,7 @@ def _build_render_setup_info(
         "runner_script_overrides": dict(artifact_store.runner_script_overrides),
         "wherobots_external_id": wherobots_config.external_id,
         "wherobots_role_arn": wherobots_config.role_arn,
+        "wherobots_version": wherobots_config.version,
         "aws_region": wherobots_config.aws_region,
         "databricks_conf": databricks_config.cluster_conf,
         "databricks_extra_libraries": list(databricks_config.extra_libraries),

--- a/src/overture_airflow_provider/setup_info.py
+++ b/src/overture_airflow_provider/setup_info.py
@@ -41,6 +41,7 @@ SERIALIZABLE_KEYS = (
     "runner_script_overrides",
     "wherobots_external_id",
     "wherobots_role_arn",
+    "wherobots_version",
     "aws_region",
     "databricks_conf",
     "databricks_extra_libraries",

--- a/src/overture_airflow_provider/spark_platform_handlers.py
+++ b/src/overture_airflow_provider/spark_platform_handlers.py
@@ -578,7 +578,9 @@ class WherobotsPlatformHandler(SparkPlatformHandler):
         from overture_airflow_provider._wherobots import execute_wherobots_job
 
         # Wherobots has no upstream Airflow trigger, so it runs synchronously and
-        # returns the final result with no deferral.
+        # returns the final result with no deferral. The runtime ``version`` is
+        # derived from the SparkImpl (GA for WherobotsDB 1.x) — see
+        # wherobots_run_version.
         result = execute_wherobots_job(
             setup_info=self.setup_info,
             package_info=package_info,
@@ -592,7 +594,6 @@ class WherobotsPlatformHandler(SparkPlatformHandler):
             wherobots_role_arn=wherobots_role_arn,
             task_id=task_id,
             context=context,
-            version="preview",
         )
         return {"trigger": None, "result": result}
 

--- a/src/overture_airflow_provider/spark_platform_handlers.py
+++ b/src/overture_airflow_provider/spark_platform_handlers.py
@@ -578,8 +578,8 @@ class WherobotsPlatformHandler(SparkPlatformHandler):
         from overture_airflow_provider._wherobots import execute_wherobots_job
 
         # Wherobots has no upstream Airflow trigger, so it runs synchronously and
-        # returns the final result with no deferral. The runtime ``version`` is
-        # omitted (GA) unless the caller set WherobotsConfig.version.
+        # returns the final result with no deferral. The runtime ``version``
+        # comes from WherobotsConfig.version ("latest" by default).
         result = execute_wherobots_job(
             setup_info=self.setup_info,
             package_info=package_info,

--- a/src/overture_airflow_provider/spark_platform_handlers.py
+++ b/src/overture_airflow_provider/spark_platform_handlers.py
@@ -579,8 +579,7 @@ class WherobotsPlatformHandler(SparkPlatformHandler):
 
         # Wherobots has no upstream Airflow trigger, so it runs synchronously and
         # returns the final result with no deferral. The runtime ``version`` is
-        # derived from the SparkImpl (GA for WherobotsDB 1.x) — see
-        # wherobots_run_version.
+        # omitted (GA) unless the caller set WherobotsConfig.version.
         result = execute_wherobots_job(
             setup_info=self.setup_info,
             package_info=package_info,

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -1585,6 +1585,63 @@ class TestWherobotsExecuteJob:
         result, _ = self._run(simulate_submit=False)
         assert "job_url" not in result
 
+    def test_ga_impl_omits_runtime_version(self):
+        # Regression for #81: version="preview" was hardcoded, submitting
+        # Scala 2.12 JARs to the WherobotsDB 2.x (Spark 4 / Scala 2.13)
+        # runtime. WHEROBOTS_v1_5_0 must target GA, i.e. omit ``version``.
+        _, kwargs = self._run()
+        assert "version" not in kwargs
+
+
+class TestWherobotsRunVersion:
+    """Deriving the Wherobots run-API ``version`` from the SparkImpl (#81)."""
+
+    def _build(self, **overrides):
+        from overture_airflow_provider._wherobots import build_wherobots_operator_kwargs
+
+        kwargs = dict(
+            setup_info=_wherobots_setup_info(),
+            package_info={
+                "py_files": [],
+                "script_location": "",
+                "python_packages_or_jars_list": [
+                    {"sourceType": "FILE", "filePath": "s3://bucket/my-pipeline-1.0.jar"}
+                ],
+            },
+            jar_info={"jars_s3": []},
+            module_name="",
+            class_name="com.example.Main",
+            extra_spark_conf={},
+            spark_cluster_size="",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            wherobots_role_arn="arn:aws:iam::123456789012:role/test",
+            task_id="execute_spark_job",
+            resolve_region=False,
+        )
+        kwargs.update(overrides)
+        return build_wherobots_operator_kwargs(**kwargs)
+
+    def test_wherobotsdb_1x_maps_to_none(self):
+        from overture_airflow_provider._wherobots import wherobots_run_version
+
+        assert wherobots_run_version("1.5.0") is None
+
+    def test_wherobotsdb_2x_maps_to_preview(self):
+        from overture_airflow_provider._wherobots import wherobots_run_version
+
+        assert wherobots_run_version("2.30.2") == "preview"
+
+    def test_default_derives_ga_and_omits_version_field(self):
+        built = self._build()
+        assert "version" not in built["operator_kwargs"]
+        assert "version" not in built["submit_payload"]
+
+    def test_explicit_version_override_is_kept(self):
+        built = self._build(version="preview")
+        assert built["operator_kwargs"]["version"] == "preview"
+        assert built["submit_payload"]["version"] == "preview"
+
 
 class TestSparkJobLink:
     """Tests for SparkJobLink.get_link."""

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -1656,11 +1656,6 @@ class TestWherobotsRunVersion:
         assert "version" not in built["operator_kwargs"]
         assert "version" not in built["submit_payload"]
 
-    def test_explicit_version_argument_wins(self):
-        built = self._build(version="preview")
-        assert built["operator_kwargs"]["version"] == "preview"
-        assert built["submit_payload"]["version"] == "preview"
-
 
 class TestSparkJobLink:
     """Tests for SparkJobLink.get_link."""

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -1588,19 +1588,19 @@ class TestWherobotsExecuteJob:
     def test_ga_impl_omits_runtime_version(self):
         # Regression for #81: version="preview" was hardcoded, submitting
         # Scala 2.12 JARs to the WherobotsDB 2.x (Spark 4 / Scala 2.13)
-        # runtime. WHEROBOTS_v1_5_0 must target GA, i.e. omit ``version``.
+        # runtime. By default ``version`` must be omitted so the API targets GA.
         _, kwargs = self._run()
         assert "version" not in kwargs
 
 
 class TestWherobotsRunVersion:
-    """Deriving the Wherobots run-API ``version`` from the SparkImpl (#81)."""
+    """The Wherobots run-API ``version`` field: GA by default, opt-in override (#81)."""
 
-    def _build(self, **overrides):
+    def _build(self, setup_info=None, **overrides):
         from overture_airflow_provider._wherobots import build_wherobots_operator_kwargs
 
         kwargs = dict(
-            setup_info=_wherobots_setup_info(),
+            setup_info=setup_info or _wherobots_setup_info(),
             package_info={
                 "py_files": [],
                 "script_location": "",
@@ -1622,22 +1622,25 @@ class TestWherobotsRunVersion:
         kwargs.update(overrides)
         return build_wherobots_operator_kwargs(**kwargs)
 
-    def test_wherobotsdb_1x_maps_to_none(self):
-        from overture_airflow_provider._wherobots import wherobots_run_version
-
-        assert wherobots_run_version("1.5.0") is None
-
-    def test_wherobotsdb_2x_maps_to_preview(self):
-        from overture_airflow_provider._wherobots import wherobots_run_version
-
-        assert wherobots_run_version("2.30.2") == "preview"
-
-    def test_default_derives_ga_and_omits_version_field(self):
+    def test_default_omits_version_field(self):
         built = self._build()
         assert "version" not in built["operator_kwargs"]
         assert "version" not in built["submit_payload"]
 
-    def test_explicit_version_override_is_kept(self):
+    def test_wherobots_config_version_override_is_used(self):
+        # WherobotsConfig.version flows through setup_info as wherobots_version.
+        setup_info = {**_wherobots_setup_info(), "wherobots_version": "preview"}
+        built = self._build(setup_info=setup_info)
+        assert built["operator_kwargs"]["version"] == "preview"
+        assert built["submit_payload"]["version"] == "preview"
+
+    def test_empty_config_version_still_omits_field(self):
+        setup_info = {**_wherobots_setup_info(), "wherobots_version": ""}
+        built = self._build(setup_info=setup_info)
+        assert "version" not in built["operator_kwargs"]
+        assert "version" not in built["submit_payload"]
+
+    def test_explicit_version_argument_wins(self):
         built = self._build(version="preview")
         assert built["operator_kwargs"]["version"] == "preview"
         assert built["submit_payload"]["version"] == "preview"

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -140,6 +140,7 @@ def _wherobots_setup_info():
         "job_runner_wheel_prefix": None,
         "wherobots_external_id": "test-external-id",
         "wherobots_role_arn": "arn:aws:iam::123456789012:role/test-role",
+        "wherobots_version": "latest",
         "aws_region": "us-east-1",
         "databricks_conf": None,
         "glue_execution_class": "STANDARD",
@@ -1585,16 +1586,16 @@ class TestWherobotsExecuteJob:
         result, _ = self._run(simulate_submit=False)
         assert "job_url" not in result
 
-    def test_ga_impl_omits_runtime_version(self):
+    def test_ga_impl_targets_latest_runtime_by_default(self):
         # Regression for #81: version="preview" was hardcoded, submitting
         # Scala 2.12 JARs to the WherobotsDB 2.x (Spark 4 / Scala 2.13)
-        # runtime. By default ``version`` must be omitted so the API targets GA.
+        # runtime. The default must target the stable channel ("latest").
         _, kwargs = self._run()
-        assert "version" not in kwargs
+        assert kwargs["version"] == "latest"
 
 
 class TestWherobotsRunVersion:
-    """The Wherobots run-API ``version`` field: GA by default, opt-in override (#81)."""
+    """The Wherobots run-API ``version`` field: "latest" by default, opt-in override (#81)."""
 
     def _build(self, setup_info=None, **overrides):
         from overture_airflow_provider._wherobots import build_wherobots_operator_kwargs
@@ -1622,10 +1623,10 @@ class TestWherobotsRunVersion:
         kwargs.update(overrides)
         return build_wherobots_operator_kwargs(**kwargs)
 
-    def test_default_omits_version_field(self):
+    def test_default_targets_latest(self):
         built = self._build()
-        assert "version" not in built["operator_kwargs"]
-        assert "version" not in built["submit_payload"]
+        assert built["operator_kwargs"]["version"] == "latest"
+        assert built["submit_payload"]["version"] == "latest"
 
     def test_wherobots_config_version_override_is_used(self):
         # WherobotsConfig.version flows through setup_info as wherobots_version.
@@ -1634,8 +1635,23 @@ class TestWherobotsRunVersion:
         assert built["operator_kwargs"]["version"] == "preview"
         assert built["submit_payload"]["version"] == "preview"
 
-    def test_empty_config_version_still_omits_field(self):
+    def test_none_config_version_omits_field(self):
+        setup_info = {**_wherobots_setup_info(), "wherobots_version": None}
+        built = self._build(setup_info=setup_info)
+        assert "version" not in built["operator_kwargs"]
+        assert "version" not in built["submit_payload"]
+
+    def test_empty_config_version_omits_field(self):
         setup_info = {**_wherobots_setup_info(), "wherobots_version": ""}
+        built = self._build(setup_info=setup_info)
+        assert "version" not in built["operator_kwargs"]
+        assert "version" not in built["submit_payload"]
+
+    def test_missing_config_key_omits_field(self):
+        # Older serialized setup_info (pre-upgrade XCom) lacks the key; the
+        # field is omitted and the API's own default ("latest") applies.
+        setup_info = _wherobots_setup_info()
+        del setup_info["wherobots_version"]
         built = self._build(setup_info=setup_info)
         assert "version" not in built["operator_kwargs"]
         assert "version" not in built["submit_payload"]

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -126,6 +126,24 @@ def test_render_wherobots_skips_region_resolution():
     assert isinstance(region, str)
 
 
+def test_render_wherobots_omits_version_by_default():
+    # Regression for #81: rendered output must match the real submission —
+    # no version field means the GA runtime.
+    result = render_spark_job(spark_impl_name="WHEROBOTS_v1_5_0", **_COMMON_KWARGS)
+    assert "version" not in result.operator_kwargs
+    assert "version" not in result.submit_payload
+
+
+def test_render_wherobots_honors_config_version_override():
+    result = render_spark_job(
+        spark_impl_name="WHEROBOTS_v1_5_0",
+        wherobots_config=WherobotsConfig(version="preview"),
+        **_COMMON_KWARGS,
+    )
+    assert result.operator_kwargs["version"] == "preview"
+    assert result.submit_payload["version"] == "preview"
+
+
 _WHEROBOTS_CONFIG_WITH_ROLE = WherobotsConfig(role_arn="arn:aws:iam::123456789012:role/wb-access")
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -126,12 +126,12 @@ def test_render_wherobots_skips_region_resolution():
     assert isinstance(region, str)
 
 
-def test_render_wherobots_omits_version_by_default():
+def test_render_wherobots_targets_latest_by_default():
     # Regression for #81: rendered output must match the real submission —
-    # no version field means the GA runtime.
+    # the stable "latest" channel, never a hardcoded "preview".
     result = render_spark_job(spark_impl_name="WHEROBOTS_v1_5_0", **_COMMON_KWARGS)
-    assert "version" not in result.operator_kwargs
-    assert "version" not in result.submit_payload
+    assert result.operator_kwargs["version"] == "latest"
+    assert result.submit_payload["version"] == "latest"
 
 
 def test_render_wherobots_honors_config_version_override():


### PR DESCRIPTION
## Summary

Fixes #81 (moved from OvertureMaps/tf-data-platform#4929).

Every Wherobots submission hardcoded `version="preview"`, which resolves to the WherobotsDB 2.x stack (**Spark 4 / Scala 2.13**). `SparkImpl.WHEROBOTS_v1_5_0` declares **Spark 3.5 / Scala 2.12**, so any Scala 2.12 JAR died at driver class-load time:

```
Exception in thread "main" java.lang.NoClassDefFoundError: scala/Serializable
Caused by: java.lang.ClassNotFoundException: scala.Serializable
```

Python jobs happened to survive on the preview runtime, which masked the bug.

## Changes

- **New `WherobotsConfig.version` field, default `"latest"`** — the run API's own default and its stable GA channel, so the config and rendered payloads are self-documenting. Set `"preview"` to opt into the preview channel deliberately; set `None` to omit the field from the submission entirely.
- The config field is the **single source of truth** for the runtime channel: it flows through `setup_info` as `wherobots_version` (added to `SERIALIZABLE_KEYS` per the XCom contract) and through `render_spark_job`'s setup-info builder, so rendered output matches real submissions. The vestigial `version=` pass-through argument on `build_wherobots_operator_kwargs` / `execute_wherobots_job` (private module) was removed — it existed only for the old hardcoded value.
- A missing/empty `wherobots_version` omits the field (the API then applies its own `latest` default), keeping pre-upgrade serialized `setup_info` working.
- `WherobotsPlatformHandler.submit_job` no longer passes a hardcoded version.
- `wherobots` extra now requires `airflow-providers-wherobots>=1.4.3`, the first operator release accepting the `version` kwarg (already an implicit requirement of the old hardcoded value).
- CHANGELOG entry; AGENTS.md quick-reference updated.

## Testing

- New/updated tests:
  - `TestWherobotsExecuteJob::test_ga_impl_targets_latest_runtime_by_default` — full submission path passes `version="latest"` to `WherobotsRunOperator` by default.
  - `TestWherobotsRunVersion` — default `"latest"` in both `operator_kwargs`/`submit_payload`; config `"preview"` honored; `None`/empty/missing config key omits the field.
  - `test_render_wherobots_targets_latest_by_default` / `test_render_wherobots_honors_config_version_override` — public render path matches submission behavior.
- Full suite: `uv run pytest` — 540 passed. `ruff check` / `ruff format --check` clean.
- Not verified live against Wherobots Cloud (acceptance criterion in #81: a Scala job with `SparkImpl=WHEROBOTS_v1_5_0` completes on Wherobots with parameters that succeed on Glue).

## Impact

- Behavior change: Wherobots submissions now target the **stable `latest` runtime** by default instead of preview — matching what `WHEROBOTS_v1_5_0` (Spark 3.5 / Scala 2.12 / Python 3.11) declares. Opt back into preview with `WherobotsConfig(version="preview")`.
- Internal-only signature change: the `version=` argument was removed from the private `_wherobots` helpers; the public surface (`spark_agnostic_task_group` + config dataclasses) only gains the optional `WherobotsConfig.version` field.
