### PR TITLE
[BUG] Branch Databricks cluster_log_conf by cloud; AWS gets s3, not dbfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-25
+
+### Fixed
+
+- **Databricks `cluster_log_conf` hardcoded a `dbfs` destination, rejected on
+  AWS UC-first workspaces.** `setup_databricks_cluster` always wrote
+  `{"dbfs": {"destination": ...}}` built from `DatabricksConfig.dbfs_root_template`,
+  regardless of `DatabricksConfig.cloud`. Databricks' Clusters API only
+  accepts `dbfs` or `s3` destinations, and UC-first AWS workspaces (one
+  workspace per managed account, no legacy DBFS root) reject the `dbfs` one
+  outright (`INVALID_PARAMETER_VALUE: Invalid cluster log storage info`).
+  Confirmed live against `tf-data-platform`'s AWS Databricks smoke test
+  (fixes #86). Cluster log delivery now branches on `cloud` the same way #79
+  branched `*_attributes`: AWS gets an `s3` destination built from the same
+  `s3_assets_bucket`/`s3_assets_root` the Glue/Wherobots builders already use,
+  Azure/GCP keep the `dbfs` destination.
+
+### Deprecated
+
+- **`DatabricksConfig.dbfs_root_template`** (and the underlying DBFS cluster
+  log path). Databricks is deprecating the legacy DBFS root in favor of Unity
+  Catalog volumes/external locations; this field and its `dbfs` branch will be
+  removed in a future major version (OvertureMaps/overture-airflow-provider#87).
+
 ## [0.10.0] - 2026-08-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.10.0"
+version = "0.10.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -159,6 +159,33 @@ def discover_databricks_cloud(databricks_conn_id: str) -> str:
     )
 
 
+def _build_cluster_log_conf(cloud: str, setup_info: dict, run_identifier: str) -> dict:
+    """Build the ``cluster_log_conf`` destination for the target cloud.
+
+    AWS UC-first workspaces commonly don't grant legacy DBFS root access, so
+    AWS gets an ``s3`` destination built from the same asset-staging bucket
+    the Glue/Wherobots builders already use (see #86). Azure/GCP keep the
+    ``dbfs`` destination via ``DatabricksConfig.dbfs_root_template``.
+
+    ``dbfs`` is a legacy opt-in path: Databricks is deprecating the DBFS root
+    in favor of Unity Catalog volumes/external locations, so
+    ``dbfs_root_template`` and this branch will be removed in a future major
+    version (OvertureMaps/overture-airflow-provider#87). Prefer ``cloud="aws"``
+    (or a UC-native destination once one is added) on new setups.
+    """
+    if cloud == "aws":
+        s3_bucket = setup_info["s3_assets_bucket"]
+        s3_root = setup_info["s3_assets_root"]
+        destination = f"s3://{s3_bucket}/{s3_root}/{run_identifier}/sparkLogs"
+        return {"s3": {"destination": destination}}
+
+    dbfs_root = setup_info["databricks_dbfs_root_template"].format(
+        s3_assets_root=setup_info["s3_assets_root"]
+    )
+    destination = f"{dbfs_root}/{run_identifier}/sparkLogs"
+    return {"dbfs": {"destination": destination}}
+
+
 def _resolve_databricks_cloud(setup_info: dict) -> str:
     """Resolve the target cloud: explicit override wins, else auto-discover.
 
@@ -276,15 +303,6 @@ def setup_databricks_cluster(
 
     py_pi_client = setup_info["py_pi_client"]
 
-    # DBFS layout (templates caller-supplied to keep platform paths configurable).
-    dbfs_root = setup_info["databricks_dbfs_root_template"].format(
-        s3_assets_root=setup_info["s3_assets_root"]
-    )
-    dbfs_prefix = f"{dbfs_root}/{run_identifier}"
-    cluster_logs_path = f"{dbfs_prefix}/sparkLogs"
-
-    print(f"Databricks logs_path: {cluster_logs_path}")
-
     # extra_libraries lets the caller pin transitive deps (e.g. numpy/geopandas)
     # without the provider hardcoding versions.
     extra_libraries = setup_info.get("databricks_extra_libraries", []) or []
@@ -328,6 +346,9 @@ def setup_databricks_cluster(
 
     node_config = _resolve_databricks_node_config(setup_info)
     cloud = _resolve_databricks_cloud(setup_info)
+
+    cluster_log_conf = _build_cluster_log_conf(cloud, setup_info, run_identifier)
+    print(f"Databricks cluster_log_conf: {cluster_log_conf}")
 
     databricks_spark_conf = setup_info.get("databricks_spark_conf", {}) or {}
     databricks_spark_env_vars = setup_info.get("databricks_spark_env_vars", {}) or {}
@@ -377,7 +398,7 @@ def setup_databricks_cluster(
                 }
             }
         ],
-        "cluster_log_conf": {"dbfs": {"destination": cluster_logs_path}},
+        "cluster_log_conf": cluster_log_conf,
         "custom_tags": custom_tags,
     }
 

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -303,8 +303,16 @@ class DatabricksConfig:
         extra_libraries: Extra ``{"pypi": {"package": "..."}}`` library entries
             appended to the auto-generated cluster libraries list. Use for
             pinning environment-specific transitive deps.
-        dbfs_root_template: Template for the DBFS root used to stage job assets.
+        dbfs_root_template: Template for the DBFS root used to stage job assets
+            and, on non-AWS clouds, the ``cluster_log_conf`` destination.
             ``{s3_assets_root}`` is substituted at runtime.
+
+            Deprecated: DBFS is Databricks' legacy filesystem, superseded by
+            Unity Catalog volumes/external locations, and this opt-in path
+            will be removed in a future major version; see
+            OvertureMaps/overture-airflow-provider#87. AWS callers already
+            avoid it by setting ``cloud="aws"``, which routes cluster logs
+            through ``s3://{s3_assets_bucket}/...`` instead.
         workspace_scripts_path_template: Template for the workspace path
             holding the runner notebook and init script. ``{s3_assets_root}`` is
             substituted at runtime. Use a **bare** workspace path (e.g.

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -1043,6 +1043,45 @@ class TestDatabricksSetupCluster:
         assert "azure_attributes" not in cluster
         assert cluster["node_type_id"].startswith("m5d.")
 
+    def test_aws_cloud_sets_s3_cluster_log_conf(self):
+        # Regression for #86: the cluster builder used to hardcode a `dbfs`
+        # cluster_log_conf destination with no cloud branch, which UC-first AWS
+        # workspaces reject (no legacy DBFS root access).
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = "aws"
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        cluster_log_conf = result["new_cluster"]["cluster_log_conf"]
+        assert "s3" in cluster_log_conf
+        assert "dbfs" not in cluster_log_conf
+        assert cluster_log_conf["s3"]["destination"].startswith("s3://test-bucket/")
+
+    def test_azure_cloud_keeps_dbfs_cluster_log_conf(self):
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = "azure"
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        cluster_log_conf = result["new_cluster"]["cluster_log_conf"]
+        assert "dbfs" in cluster_log_conf
+        assert "s3" not in cluster_log_conf
+        assert cluster_log_conf["dbfs"]["destination"].startswith("dbfs:/FileStore/deploy/")
+
     def test_cloud_discovery_fills_in_when_unset(self, monkeypatch):
         import overture_airflow_provider._databricks as dbx
 


### PR DESCRIPTION
## Context

This is a bug patch from the effort to switch our existing Databricks workloads from Azure -> AWS.

----

`setup_databricks_cluster` hardcoded `cluster_log_conf` to a `dbfs` destination with no cloud branch. UC-first AWS workspaces (one workspace per managed account, no legacy DBFS root access) reject it outright:

```
Unexpected user error while preparing the cluster for the job. Cause: INVALID_PARAMETER_VALUE: Invalid cluster log storage info, please refer to the API doc about what storage is supported for cluster log delivery.
```

Confirmed live against `tf-data-platform`'s AWS Databricks smoke test ([run 32773638477](https://github.com/OvertureMaps/tf-data-platform/actions/runs/32773638477)), same class of bug as #78/#79 (Azure-first default, no AWS branch).

`_build_cluster_log_conf` now branches on `DatabricksConfig.cloud` the same way `#79` branched `*_attributes`: AWS gets an `s3` destination built from `s3_assets_bucket`/`s3_assets_root`, the same asset-staging bucket the Glue/Wherobots builders already use; Azure/GCP keep the `dbfs` destination via `dbfs_root_template`.

> [!NOTE]
> `dbfs_root_template` is flagged deprecated in the `DatabricksConfig` docstring and the `_build_cluster_log_conf` comment. Databricks is deprecating the legacy DBFS root in favor of Unity Catalog volumes/external locations, and this isn't AWS-specific, Azure/GCP just haven't hit the same enforcement yet. Filed OvertureMaps/overture-airflow-provider#87 (v2.0.0 milestone) to remove the DBFS path once callers have migrated.

Bumped to `0.9.1` with a changelog entry.

Fixes #86.

## Testing

Added `test_aws_cloud_sets_s3_cluster_log_conf` and `test_azure_cloud_keeps_dbfs_cluster_log_conf` to `tests/test_platform_handlers.py`, following the existing `test_aws_cloud_sets_aws_attributes_and_ec2_worker_type` pattern.

Couldn't execute the suite in this sandbox: `apache-airflow` 3.3.1's `airflow.sdk` import chain hits `os.register_at_fork`, which doesn't exist on Windows (this repo's own `AGENTS.md` notes Airflow isn't Windows-supported). Verified `_build_cluster_log_conf` directly instead (isolated call, no Airflow import) for `aws`/`azure`/`gcp`, and ran `ruff check`/`ruff format --check` on the changed files, both clean.