### PR TITLE
[BUG] Set region on Databricks AWS S3 cluster_log_conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-27
+
+### Fixed
+
+- **AWS Databricks clusters set an `s3` `cluster_log_conf` with no `region`,
+  which Databricks' `S3StorageInfo` requires.** Confirmed live against
+  `tf-data-platform`'s AWS Databricks smoke test on top of the #90/v0.10.2
+  instance-profile fix: the cluster now reaches creation but Databricks
+  rejects it (`INVALID_PARAMETER_VALUE: S3 cluster log destination is
+  provided but neither region nor endpoint is set.`), a distinct bug from
+  #86/#90 (fixes #92). `_build_cluster_log_conf` now sets `s3.region` via
+  `boto3.Session().region_name` (the standard AWS SDK chain:
+  `AWS_REGION`/`AWS_DEFAULT_REGION` env vars, `~/.aws/config`, etc.), with no
+  hardcoded fallback. An unresolved region flows through as `None` so
+  Databricks rejects it clearly instead of this provider guessing one.
+
 ## [0.11.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.11.1] - 2026-08-27
+## [0.12.0] - 2026-08-27
 
 ### Fixed
 
@@ -19,9 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   provided but neither region nor endpoint is set.`), a distinct bug from
   #86/#90 (fixes #92). `_build_cluster_log_conf` now sets `s3.region` via
   `boto3.Session().region_name` (the standard AWS SDK chain:
-  `AWS_REGION`/`AWS_DEFAULT_REGION` env vars, `~/.aws/config`, etc.), with no
-  hardcoded fallback. An unresolved region flows through as `None` so
-  Databricks rejects it clearly instead of this provider guessing one.
+  `AWS_REGION`/`AWS_DEFAULT_REGION` env vars, `~/.aws/config`, etc.) unless
+  `DatabricksConfig.aws_cluster_log_region` overrides it. No hardcoded
+  fallback: an unresolved region flows through as `None` so Databricks
+  rejects it clearly instead of this provider guessing one. Added
+  `DatabricksConfig.aws_cluster_log_endpoint` too, for S3-compatible
+  destinations that satisfy `S3StorageInfo` via `endpoint` instead of
+  `region`.
 
 ## [0.11.0] - 2026-08-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.11.0"
+version = "0.11.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.11.1"
+version = "0.12.0"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -175,19 +175,21 @@ def _build_cluster_log_conf(cloud: str, setup_info: dict, run_identifier: str) -
     version (OvertureMaps/overture-airflow-provider#87). Prefer ``cloud="aws"``
     (or a UC-native destination once one is added) on new setups.
 
-    Databricks' ``S3StorageInfo`` requires ``region`` or ``endpoint`` to be
-    set, so the AWS branch also resolves ``region`` via
-    ``boto3.Session().region_name`` (the standard AWS SDK chain:
-    ``AWS_REGION``/``AWS_DEFAULT_REGION`` env vars, ``~/.aws/config``, etc.).
-    No fallback is applied. An unresolved region flows through as ``None``
-    and Databricks rejects it with a clear error rather than this provider
-    silently guessing a region.
+    Databricks' ``S3StorageInfo`` requires ``region`` or ``endpoint``, filled
+    in from ``DatabricksConfig.aws_cluster_log_region``/``aws_cluster_log_endpoint``
+    (region falls back to ``boto3.Session().region_name`` if unset; see
+    those fields' docs for details).
     """
     if cloud == "aws":
         s3_bucket = setup_info["s3_assets_bucket"]
         s3_root = setup_info["s3_assets_root"]
         destination = f"s3://{s3_bucket}/{s3_root}/{run_identifier}/sparkLogs"
-        return {"s3": {"destination": destination, "region": boto3.Session().region_name}}
+        region = setup_info.get("databricks_aws_cluster_log_region") or boto3.Session().region_name
+        s3_conf = {"destination": destination, "region": region}
+        endpoint = setup_info.get("databricks_aws_cluster_log_endpoint")
+        if endpoint:
+            s3_conf["endpoint"] = endpoint
+        return {"s3": s3_conf}
 
     dbfs_root = setup_info["databricks_dbfs_root_template"].format(
         s3_assets_root=setup_info["s3_assets_root"]

--- a/src/overture_airflow_provider/_databricks.py
+++ b/src/overture_airflow_provider/_databricks.py
@@ -2,6 +2,8 @@
 
 import json
 
+import boto3
+
 from overture_airflow_provider._retry_guard import record_launched_run
 from overture_airflow_provider.cluster_sizing import DatabricksClusterSize
 from overture_airflow_provider.spark_platform_handlers import _merge_spark_conf
@@ -172,12 +174,20 @@ def _build_cluster_log_conf(cloud: str, setup_info: dict, run_identifier: str) -
     ``dbfs_root_template`` and this branch will be removed in a future major
     version (OvertureMaps/overture-airflow-provider#87). Prefer ``cloud="aws"``
     (or a UC-native destination once one is added) on new setups.
+
+    Databricks' ``S3StorageInfo`` requires ``region`` or ``endpoint`` to be
+    set, so the AWS branch also resolves ``region`` via
+    ``boto3.Session().region_name`` (the standard AWS SDK chain:
+    ``AWS_REGION``/``AWS_DEFAULT_REGION`` env vars, ``~/.aws/config``, etc.).
+    No fallback is applied. An unresolved region flows through as ``None``
+    and Databricks rejects it with a clear error rather than this provider
+    silently guessing a region.
     """
     if cloud == "aws":
         s3_bucket = setup_info["s3_assets_bucket"]
         s3_root = setup_info["s3_assets_root"]
         destination = f"s3://{s3_bucket}/{s3_root}/{run_identifier}/sparkLogs"
-        return {"s3": {"destination": destination}}
+        return {"s3": {"destination": destination, "region": boto3.Session().region_name}}
 
     dbfs_root = setup_info["databricks_dbfs_root_template"].format(
         s3_assets_root=setup_info["s3_assets_root"]

--- a/src/overture_airflow_provider/_setup.py
+++ b/src/overture_airflow_provider/_setup.py
@@ -131,6 +131,8 @@ def setup_spark_job(
         "databricks_gpu": databricks_config.gpu,
         "databricks_cloud": databricks_config.cloud,
         "databricks_aws_instance_profile_arn": databricks_config.aws_instance_profile_arn,
+        "databricks_aws_cluster_log_region": databricks_config.aws_cluster_log_region,
+        "databricks_aws_cluster_log_endpoint": databricks_config.aws_cluster_log_endpoint,
         "databricks_spot_availability": databricks_config.spot_availability,
         "databricks_aws_spot_bid_price_percent": databricks_config.aws_spot_bid_price_percent,
         "databricks_azure_spot_bid_max_price": databricks_config.azure_spot_bid_max_price,

--- a/src/overture_airflow_provider/config.py
+++ b/src/overture_airflow_provider/config.py
@@ -386,6 +386,18 @@ class DatabricksConfig:
             OvertureMaps/overture-airflow-provider#90); ignored on Azure/GCP.
             Leave empty to omit ``instance_profile_arn`` entirely, matching the
             provider's prior behavior.
+        aws_cluster_log_region: Overrides the ``s3.region`` set on the
+            ``cluster_log_conf`` when ``cloud == "aws"`` (Databricks'
+            ``S3StorageInfo`` requires ``region`` or ``endpoint``; see
+            OvertureMaps/overture-airflow-provider#92). Leave empty to
+            auto-detect via ``boto3.Session().region_name`` (the standard AWS
+            SDK chain: ``AWS_REGION``/``AWS_DEFAULT_REGION`` env vars,
+            ``~/.aws/config``, etc.); ignored on Azure/GCP.
+        aws_cluster_log_endpoint: Sets ``s3.endpoint`` on the
+            ``cluster_log_conf`` when ``cloud == "aws"``, for S3-compatible
+            endpoints (e.g. MinIO) that satisfy ``S3StorageInfo`` without a
+            region. Leave empty to omit ``endpoint`` entirely; ignored on
+            Azure/GCP.
         spot_availability: Overrides the cloud attributes' ``availability``
             key (e.g. ``aws_attributes.availability``). Leave empty to keep
             the provider's per-cloud spot-with-fallback default
@@ -416,6 +428,8 @@ class DatabricksConfig:
     gpu: bool = False
     cloud: str = "azure"
     aws_instance_profile_arn: str = ""
+    aws_cluster_log_region: str = ""
+    aws_cluster_log_endpoint: str = ""
     spot_availability: str = ""
     aws_spot_bid_price_percent: int | None = None
     azure_spot_bid_max_price: int | float | None = None

--- a/src/overture_airflow_provider/setup_info.py
+++ b/src/overture_airflow_provider/setup_info.py
@@ -57,6 +57,8 @@ SERIALIZABLE_KEYS = (
     "databricks_gpu",
     "databricks_cloud",
     "databricks_aws_instance_profile_arn",
+    "databricks_aws_cluster_log_region",
+    "databricks_aws_cluster_log_endpoint",
     "databricks_spot_availability",
     "databricks_aws_spot_bid_price_percent",
     "databricks_azure_spot_bid_max_price",

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -1093,6 +1093,50 @@ class TestDatabricksSetupCluster:
         cluster_log_conf = result["new_cluster"]["cluster_log_conf"]
         assert cluster_log_conf["s3"]["region"] == "us-west-2"
 
+    def test_aws_cluster_log_region_override_skips_boto3(self, monkeypatch):
+        # DatabricksConfig.aws_cluster_log_region overrides boto3 auto-detection.
+        import overture_airflow_provider._databricks as dbx
+
+        monkeypatch.setattr(
+            dbx.boto3,
+            "Session",
+            lambda: (_ for _ in ()).throw(AssertionError("boto3.Session() should not be called")),
+        )
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = "aws"
+        handler.setup_info["databricks_aws_cluster_log_region"] = "eu-west-1"
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        cluster_log_conf = result["new_cluster"]["cluster_log_conf"]
+        assert cluster_log_conf["s3"]["region"] == "eu-west-1"
+
+    def test_aws_cluster_log_endpoint_is_set_when_configured(self):
+        # DatabricksConfig.aws_cluster_log_endpoint sets s3.endpoint for
+        # S3-compatible destinations (e.g. MinIO).
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = "aws"
+        handler.setup_info["databricks_aws_cluster_log_endpoint"] = "https://minio.internal:9000"
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        cluster_log_conf = result["new_cluster"]["cluster_log_conf"]
+        assert cluster_log_conf["s3"]["endpoint"] == "https://minio.internal:9000"
+
     def test_azure_cloud_keeps_dbfs_cluster_log_conf(self):
         handler = DatabricksPlatformHandler(_databricks_setup_info())
         handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"

--- a/tests/test_platform_handlers.py
+++ b/tests/test_platform_handlers.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Mapping
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1063,6 +1064,34 @@ class TestDatabricksSetupCluster:
         assert "s3" in cluster_log_conf
         assert "dbfs" not in cluster_log_conf
         assert cluster_log_conf["s3"]["destination"].startswith("s3://test-bucket/")
+
+    def test_aws_cloud_sets_s3_cluster_log_conf_region(self, monkeypatch):
+        # Regression: Databricks' S3StorageInfo requires `region` or `endpoint`
+        # to be set, or cluster creation fails with INVALID_PARAMETER_VALUE
+        # ("S3 cluster log destination is provided but neither region nor
+        # endpoint is set."). `region` is resolved via
+        # `boto3.Session().region_name` (the standard AWS SDK chain).
+        import overture_airflow_provider._databricks as dbx
+
+        monkeypatch.setattr(
+            dbx.boto3,
+            "Session",
+            lambda: SimpleNamespace(region_name="us-west-2"),
+        )
+        handler = DatabricksPlatformHandler(_databricks_setup_info())
+        handler.setup_info["py_pi_client"].get_url.return_value = "https://fake-pypi/simple/"
+        handler.setup_info["databricks_cloud"] = "aws"
+        result = handler.setup_cluster(
+            python_packages="overture-spark==1.0",
+            spark_jar_paths="",
+            extra_spark_conf={},
+            extra_spark_env_vars="{}",
+            spark_cluster_desired_worker_cores="40",
+            spark_cluster_desired_workers="",
+            iceberg_spark_config=_mock_iceberg_rest(),
+        )
+        cluster_log_conf = result["new_cluster"]["cluster_log_conf"]
+        assert cluster_log_conf["s3"]["region"] == "us-west-2"
 
     def test_azure_cloud_keeps_dbfs_cluster_log_conf(self):
         handler = DatabricksPlatformHandler(_databricks_setup_info())


### PR DESCRIPTION
`_build_cluster_log_conf` builds the AWS `cluster_log_conf` as `{"s3": {"destination": destination}}`. Databricks' `S3StorageInfo` requires `region` or `endpoint` to be set.

Confirmed live against tf-data-platform's AWS Databricks smoke test (PR #4779, run https://github.com/OvertureMaps/tf-data-platform/actions/runs/33111981464), past the #90/v0.10.2 instance-profile fix:

```
Response: {"error_code":"INVALID_PARAMETER_VALUE","message":"S3 cluster log destination is provided but neither region nor endpoint is set.",...}, Status Code: 400
```

`_build_cluster_log_conf` now sets `s3.region` via `boto3.Session().region_name` (the standard AWS SDK chain: `AWS_REGION`/`AWS_DEFAULT_REGION` env vars, `~/.aws/config`, etc.). The failing run's task env already had `AWS_DEFAULT_REGION`/`AWS_REGION` set to `us-west-2`, so no new config is required for the common case.

Two new `DatabricksConfig` fields cover cases auto-detection can't: `aws_cluster_log_region` overrides the region outright (and skips the `boto3.Session()` call), `aws_cluster_log_endpoint` sets `s3.endpoint` for S3-compatible destinations (e.g. MinIO) that don't need a region.

No hardcoded fallback: an unresolved region flows through as `None` so Databricks rejects it with a clear error instead of this provider guessing one.

Fixes #92.

Bumped to 0.12.0 (new config fields).