### PR TITLE
[BUG] Force-pip transitive pure-Python deps matching force_pip_packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-02
+
+### Fixed
+
+- **`force_pip_packages` only matched a caller's explicitly requested top-level
+  packages, never a transitive pure-Python dependency pulled in by one of
+  them.** A Glue job crashed on startup with `botocore.exceptions.DataNotFoundError:
+  Unable to load data for: endpoints`, because `boto3`/`botocore` (transitive
+  deps of `overture-core`, which no package here declares directly) landed in
+  `--extra-py-files` and ran straight out of a zipped wheel on `sys.path`,
+  where botocore's data loader can't read its bundled `data/endpoints.json`
+  (fixes #96). `download_and_cache_python_packages` now checks every
+  downloaded pure-Python wheel's parsed package name against
+  `force_pip_packages`, the same way it already did for native wheels, and
+  routes a match to `--additional-python-modules` instead of the S3 wheel
+  cache.
+
 ## [0.12.0] - 2026-08-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "airflow-provider-overture"
-version = "0.12.0"
+version = "0.12.1"
 description = "Spark-agnostic Airflow task group for running jobs on AWS Glue, Databricks, or Wherobots from a single DAG entry point."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/overture_airflow_provider/spark_agnostic_helpers.py
+++ b/src/overture_airflow_provider/spark_agnostic_helpers.py
@@ -111,15 +111,20 @@ class SparkAgnosticHelper:
         uploads. Only **explicitly requested** packages (in ``packages``) are
         tracked and returned for install via ``--additional-python-modules``
         on Glue. Transitive native deps that exist in the target environment
-        (e.g. numpy/shapely) are not included.
+        (e.g. numpy/shapely) are not included. Pure-Python wheels, including
+        transitive ones, are additionally routed to ``--additional-python-modules``
+        when their name matches ``force_pip_packages`` (e.g. boto3/botocore,
+        whose data-file loaders can't read from inside a zipped wheel on
+        ``sys.path``).
 
         Returns:
             Tuple of:
               - comma-separated S3 paths of cached pure-Python wheels,
               - job-runner wheel local path (or None),
               - temp folder path (caller cleans up),
-              - list of explicitly requested native package specs
-                (e.g. ``['numba==0.59.0']``).
+              - list of package specs to install via pip (explicitly requested
+                native packages, plus any pure-Python package matching
+                ``force_pip_packages``, e.g. ``['numba==0.59.0']``).
         """
         # Force-install via pip for caller-configured complex packages.
         excluded_native_packages = [pkg for pkg in packages if self._force_pip_install(pkg)]
@@ -163,8 +168,9 @@ class SparkAgnosticHelper:
             if job_runner_wheel_prefix and file.startswith(job_runner_wheel_prefix):
                 job_runner_whl = wheel_path
 
+            pkg_name, version = self._parse_wheel_filename(file)
+
             if self._has_native_dependencies(file):
-                pkg_name, version = self._parse_wheel_filename(file)
                 if pkg_name:
                     if pkg_name.lower() in requested_package_names:
                         if pkg_name not in excluded_native_packages:
@@ -177,6 +183,23 @@ class SparkAgnosticHelper:
                         print(f"Native package (transitive dep, skipping): {file}")
                 else:
                     print(f"Native package (could not parse name): {file}")
+                os.remove(wheel_path)
+                continue
+
+            # Pure-Python wheel, but still route it to --additional-python-modules
+            # if it (or a transitive dep sharing this name, e.g. boto3 pulled in
+            # by overture-core) matches a caller-configured force_pip_packages
+            # substring. Some pure-Python packages (boto3/botocore) ship data
+            # files their loaders can't read from inside a zipped wheel on
+            # sys.path, so they need a real pip install, not --extra-py-files.
+            if pkg_name and self._force_pip_install(pkg_name):
+                pkg_spec = f"{pkg_name}=={version}" if version else pkg_name
+                if pkg_spec not in excluded_native_packages:
+                    excluded_native_packages.append(pkg_spec)
+                    print(
+                        f"Pure-Python package matches force_pip_packages: {file} -> "
+                        f"will install via pip: {pkg_spec}"
+                    )
                 os.remove(wheel_path)
                 continue
 

--- a/tests/test_spark_agnostic_helpers.py
+++ b/tests/test_spark_agnostic_helpers.py
@@ -34,11 +34,12 @@ def _make_s3_mock(existing_keys: set = None):
     return mock_s3
 
 
-def _make_helper(s3_mock, bucket="test-glue-assets"):
+def _make_helper(s3_mock, bucket="test-glue-assets", force_pip_packages=None):
     helper = SparkAgnosticHelper(
         job_name="test.Job",
         run_identifier="test.Job/20240101120000",
         s3_bucket=bucket,
+        force_pip_packages=force_pip_packages,
     )
     helper.s3_client = s3_mock
     return helper
@@ -121,9 +122,10 @@ class TestDownloadAndCachePythonPackages:
         requested_packages,
         existing_s3_keys=None,
         job_runner_wheel_prefix=None,
+        force_pip_packages=None,
     ):
         s3_mock = _make_s3_mock(existing_s3_keys)
-        helper = _make_helper(s3_mock)
+        helper = _make_helper(s3_mock, force_pip_packages=force_pip_packages)
 
         mock_client = MagicMock()
 
@@ -239,6 +241,29 @@ class TestDownloadAndCachePythonPackages:
         assert py_files == ""
         assert native == []
         assert len(s3._uploaded) == 0
+
+    def test_transitive_pure_python_dep_routed_to_pip_when_force_pip_matches(self):
+        """Regression test for #96: boto3/botocore break when run directly out of
+        a zipped wheel on sys.path (can't read their bundled data files), so a
+        transitive pure-Python dep matching force_pip_packages must be routed to
+        --additional-python-modules like an explicitly requested native package,
+        not uploaded to the S3 wheel cache / --extra-py-files."""
+        _, _, _, native, s3 = self._run(
+            wheel_files=["boto3-1.35.0-py3-none-any.whl"],
+            requested_packages=["overture-core"],
+            force_pip_packages=["boto3"],
+        )
+        assert native == ["boto3==1.35.0"]
+        assert len(s3._uploaded) == 0
+
+    def test_transitive_pure_python_dep_not_forced_without_match(self):
+        _, _, _, native, s3 = self._run(
+            wheel_files=["boto3-1.35.0-py3-none-any.whl"],
+            requested_packages=["overture-core"],
+            force_pip_packages=[],
+        )
+        assert native == []
+        assert len(s3._uploaded) == 1
 
 
 class TestDownloadAndCacheJars:


### PR DESCRIPTION
## Context

`force_pip_packages` only matches a caller's explicitly requested top-level packages, never a transitive pure-Python dependency pulled in by one of them. `boto3`/`botocore` (a transitive dep of `overture-core`, not declared by anything in this repo) lands in `--extra-py-files` and runs straight out of a zipped wheel on `sys.path`, where botocore's data loader can't read its bundled `data/endpoints.json`. Glue jobs crash with `botocore.exceptions.DataNotFoundError: Unable to load data for: endpoints`.

Fixes #96

## Changes

- `download_and_cache_python_packages`: parses each downloaded wheel's package name before the native-vs-pure-Python branch, previously only computed for native wheels. A pure-Python wheel matching `force_pip_packages` now routes to `--additional-python-modules` instead of the S3 wheel cache, the same handling the native-wheel path already had.

> Doesn't setting `force_pip_packages=["boto3"]` plus explicitly listing `boto3` already work around this?

Sort of, by accident. The pre-download filter strips an explicitly-listed `boto3` from `packages` and forces it into `--additional-python-modules`. But `pip download` still resolves the full transitive tree of the other requested packages, so a `boto3` wheel lands in the temp folder regardless. Being pure-Python, it still got cached to `--extra-py-files` too, pre-fix. The job ends up with `boto3` in both places, unpinned in one and duplicated in the other, and it only works if import order happens to favor the pip-installed copy. It also requires the caller to declare a dependency they never call directly. This fix removes the need for that.

## Testing

- `uv run pytest tests/test_spark_agnostic_helpers.py -v`: 29 passed, including two new regression tests (`test_transitive_pure_python_dep_routed_to_pip_when_force_pip_matches`, `test_transitive_pure_python_dep_not_forced_without_match`).
- `uv run pytest -q`: same pre-existing environment-only failures as `main` (Windows `airflow.sdk.ObjectStoragePath` import mismatch), no new failures.
- `uv run ruff check .` / `uv run ruff format --check .`: clean.

<!--:robot:-->
